### PR TITLE
Add groups.membership.list endpoint for cross-group membership queries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@
 - **Profile edits** (`app.bsky.actor.profile` + rkey `self`) use a special operation `putRecord:profile` requiring admin, regardless of authorship.
 
 ## Testing
+- `pnpm test` exits after one run (no watch mode). Redirect output to a temp file so you can inspect failures without re-running: `pnpm test > /tmp/test-output.log 2>&1` then read the file.
 - `createTestContext(overrides?)` in `tests/helpers/mock-server.ts` — builds a full `AppContext` with in-memory DBs and mocks. Pass `Partial<AppContext>` to override.
 - Default mock auth returns `{ iss: 'did:plc:testuser', aud: 'did:plc:testgroup' }`. Override `authVerifier.verify` to test other callers.
 - `seedMember(groupDb, did, role)` and `seedAuthorship(groupDb, uri, did, collection)` are the main test helpers.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3,10 +3,12 @@
 All endpoints (except `/health`) require authentication via a signed JWT in the `Authorization: Bearer <token>` header. The JWT must include:
 
 - `iss` — the caller's DID
-- `aud` — the target group's DID
+- `aud` — the target group's DID (or the service DID for cross-group queries)
 - `lxm` — the XRPC method being called
 - `jti` — a unique nonce (each token can only be used once)
 - `exp` — expiration timestamp
+
+Most endpoints target a specific group (`aud` = group DID). Cross-group endpoints under `app.certified.groups.*` target the service itself (`aud` = service DID).
 
 ## Health check
 
@@ -446,6 +448,87 @@ curl -X POST https://group-service.example.com/xrpc/app.certified.group.role.set
 
 ---
 
+## Cross-group queries
+
+These endpoints operate at the service level rather than on a single group. The JWT `aud` must be the **service DID** (not a group DID), and `lxm` must match the endpoint's NSID.
+
+**Discovering the service DID:** The service DID is published at the `/.well-known/did.json` endpoint. Resolve it once and cache it for the lifetime of your session.
+
+**Minting a service-level JWT:** Build the JWT exactly as you would for a group-level call, but set `aud` to the service DID instead of a group DID. The `iss`, `lxm`, `jti`, and `exp` fields work the same way. Sign the token with your DID's signing key as usual.
+
+### `GET /xrpc/app.certified.groups.membership.list`
+
+List all groups the authenticated user belongs to on this group service.
+
+**Authentication:** service-level (JWT `aud` = service DID)
+
+**Required role:** none (any authenticated user can list their own memberships)
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | number | 50 | Results per page (1-100) |
+| `cursor` | string | — | Pagination cursor from a previous response |
+
+**Response (200):**
+
+```json
+{
+  "groups": [
+    {
+      "groupDid": "did:plc:group123",
+      "role": "admin",
+      "joinedAt": "2026-01-15T12:00:00.000Z"
+    },
+    {
+      "groupDid": "did:plc:group456",
+      "role": "member",
+      "joinedAt": "2026-02-01T09:30:00.000Z"
+    }
+  ],
+  "cursor": "MjAyNi0wMi0wMVQwOTozMDowMFo6OmRpZDpwbGM6Z3JvdXA0NTY="
+}
+```
+
+Groups are ordered by `joinedAt ASC, groupDid ASC`. Paginate by passing the returned `cursor` value into the next request until `cursor` is absent from the response, which indicates the final page.
+
+> **Treat the cursor as opaque.** Its internal format may change between service versions. Do not construct, parse, or modify cursor values — always use them exactly as returned.
+
+**Errors:**
+
+| Code | Name | Description |
+|------|------|-------------|
+| 400 | InvalidCursor | Malformed pagination cursor |
+| 401 | AuthenticationRequired | Missing or invalid JWT |
+
+**Error response format:**
+
+```json
+{
+  "error": "InvalidCursor",
+  "message": "Invalid cursor"
+}
+```
+
+```json
+{
+  "error": "AuthenticationRequired",
+  "message": "Authentication Required"
+}
+```
+
+> **Important — single-instance scope:** This endpoint only lists groups managed by **this** group service instance. If the caller is a member of groups on other group service instances, those memberships will not appear here. There is currently no cross-service federation or discovery mechanism for memberships.
+
+**Example:**
+
+```bash
+curl "https://group-service.example.com/xrpc/app.certified.groups.membership.list?limit=10" \
+  -H "Authorization: Bearer $JWT"
+```
+
+---
+
 ## Audit log
 
 ### `GET /xrpc/app.certified.group.audit.query`
@@ -494,7 +577,7 @@ Entries are ordered newest first (`id DESC`). The `detail` field is a JSON objec
 Every audited operation produces one of the following `action` strings. Denied operations use the same action value with `"result": "denied"` and an additional `reason` field in `detail`.
 
 | Action | Trigger | `detail` fields |
-|--------|---------|-----------------|
+|--------|---------|------------------|
 | `group.register` | Group created via `app.certified.group.register` | `{ handle }` |
 | `member.add` | Member added via `member.add` | `{ memberDid, role }` |
 | `member.remove` | Member removed via `member.remove` | `{ memberDid }` |

--- a/lexicons/app/certified/group/role/set.json
+++ b/lexicons/app/certified/group/role/set.json
@@ -35,7 +35,9 @@
         { "name": "Unauthorized" },
         { "name": "Forbidden" },
         { "name": "MemberNotFound" },
-        { "name": "LastOwnerDemotion", "description": "Cannot demote the last owner — promote a replacement first" }
+        { "name": "InvalidRole", "description": "Role must be one of: member, admin, owner" },
+        { "name": "CannotModifyOwner", "description": "Cannot change owner role — use ownership transfer instead" },
+        { "name": "CannotPromoteToOwner", "description": "Cannot promote to owner — use ownership transfer instead" }
       ]
     }
   }

--- a/lexicons/app/certified/groups/membership/list.json
+++ b/lexicons/app/certified/groups/membership/list.json
@@ -1,0 +1,43 @@
+{
+  "lexicon": 1,
+  "id": "app.certified.groups.membership.list",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List groups the authenticated user belongs to on this group service.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "limit": { "type": "integer", "minimum": 1, "maximum": 100, "default": 50 },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["groups"],
+          "properties": {
+            "cursor": { "type": "string" },
+            "groups": {
+              "type": "array",
+              "items": { "type": "ref", "ref": "#groupMembership" }
+            }
+          }
+        }
+      },
+      "errors": [
+        { "name": "Unauthorized" }
+      ]
+    },
+    "groupMembership": {
+      "type": "object",
+      "required": ["groupDid", "role", "joinedAt"],
+      "properties": {
+        "groupDid": { "type": "string", "format": "did" },
+        "role": { "type": "string", "knownValues": ["member", "admin", "owner"] },
+        "joinedAt": { "type": "string", "format": "datetime" }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "vitest",
+    "test": "vitest run",
     "migrate": "tsx src/db/migrate.ts",
     "migrate:create": "tsx src/db/create-migration.ts"
   },

--- a/src/api/group/register.ts
+++ b/src/api/group/register.ts
@@ -155,12 +155,10 @@ export default function (app: Express, ctx: AppContext) {
       // Initialize per-group database and run migrations
       await ctx.groupDbs.migrateGroup(groupDid)
 
-      // Seed owner
+      // Seed owner (atomic write to both group DB and member_index)
       const groupDb = ctx.groupDbs.get(groupDid)
-      await groupDb
-        .insertInto('group_members')
-        .values({ member_did: ownerDid, role: 'owner', added_by: ownerDid })
-        .execute()
+      const groupRaw = ctx.groupDbs.getRaw(groupDid)
+      ctx.memberIndex.add(groupRaw, groupDid, ownerDid, 'owner', ownerDid)
 
       // Audit log the group creation
       await ctx.audit.log(groupDb, ownerDid, 'group.register', 'permitted', {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -11,6 +11,7 @@ import memberRemove from './member/remove.js'
 import memberList from './member/list.js'
 import roleSet from './role/set.js'
 import auditQuery from './audit/query.js'
+import membershipList from './membership/list.js'
 import groupRegister from './group/register.js'
 
 export function registerXrpcMethods(server: Server, ctx: AppContext): void {
@@ -23,6 +24,7 @@ export function registerXrpcMethods(server: Server, ctx: AppContext): void {
   memberList(server, ctx)
   roleSet(server, ctx)
   auditQuery(server, ctx)
+  membershipList(server, ctx)
 }
 
 /** Routes that live outside the XRPC server (unauthenticated, non-standard). */

--- a/src/api/member/add.ts
+++ b/src/api/member/add.ts
@@ -19,6 +19,7 @@ export default function (server: Server, ctx: AppContext) {
       }
 
       const groupDb = ctx.groupDbs.get(groupDid)
+      const groupRaw = ctx.groupDbs.getRaw(groupDid)
 
       const callerRole = await ctx.rbac.assertCan(groupDb, callerDid, 'member.add')
 
@@ -27,13 +28,8 @@ export default function (server: Server, ctx: AppContext) {
         throw new ForbiddenError('Cannot assign a role equal to or higher than your own')
       }
 
-      let member
       try {
-        member = await groupDb
-          .insertInto('group_members')
-          .values({ member_did: memberDid, role, added_by: callerDid })
-          .returning(['member_did', 'role', 'added_at'])
-          .executeTakeFirstOrThrow()
+        ctx.memberIndex.add(groupRaw, groupDid, memberDid, role, callerDid)
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)
         if (msg.includes('UNIQUE constraint failed: group_members.member_did')) {
@@ -41,6 +37,12 @@ export default function (server: Server, ctx: AppContext) {
         }
         throw err
       }
+
+      const member = await groupDb
+        .selectFrom('group_members')
+        .select(['member_did', 'role', 'added_at'])
+        .where('member_did', '=', memberDid)
+        .executeTakeFirstOrThrow()
 
       await ctx.audit.log(groupDb, callerDid, 'member.add', 'permitted', { memberDid, role })
 

--- a/src/api/member/remove.ts
+++ b/src/api/member/remove.ts
@@ -41,12 +41,10 @@ export default function (server: Server, ctx: AppContext) {
         throw new ForbiddenError('Cannot remove a member with equal or higher role')
       }
 
-      await Promise.all([
-        groupDb.deleteFrom('group_members')
-          .where('member_did', '=', memberDid)
-          .execute(),
-        ctx.audit.log(groupDb, callerDid, 'member.remove', 'permitted', { memberDid }),
-      ])
+      const groupRaw = ctx.groupDbs.getRaw(groupDid)
+      ctx.memberIndex.remove(groupRaw, groupDid, memberDid)
+
+      await ctx.audit.log(groupDb, callerDid, 'member.remove', 'permitted', { memberDid })
 
       return jsonResponse({})
     },

--- a/src/api/membership/list.ts
+++ b/src/api/membership/list.ts
@@ -1,0 +1,59 @@
+import type { Server } from '@atproto/xrpc-server'
+import { XRPCError } from '@atproto/xrpc-server'
+import type { AppContext } from '../../context.js'
+import type { ServiceAuthResult } from '../../auth/verifier.js'
+import { jsonResponse, encodeCursor, decodeCursor, sqliteToIso } from '../util.js'
+
+export default function (server: Server, ctx: AppContext) {
+  server.method('app.certified.groups.membership.list', {
+    auth: ctx.authVerifier.xrpcServiceAuth(),
+    handler: async ({ auth, params }: { auth: ServiceAuthResult; params: Record<string, unknown> }) => {
+      const callerDid = auth.credentials.callerDid
+
+      const limit = (params.limit as number) ?? 50
+      const cursor = params.cursor as string | undefined
+
+      let query = ctx.globalDb
+        .selectFrom('member_index')
+        .select(['group_did', 'role', 'added_at'])
+        .where('member_did', '=', callerDid)
+        .orderBy('added_at', 'asc')
+        .orderBy('group_did', 'asc')
+        .limit(limit + 1)
+
+      if (cursor) {
+        const decoded = decodeCursor(cursor)
+        const [cursorTs, cursorDid] = decoded.split('::')
+        if (!cursorTs || !cursorDid) {
+          throw new XRPCError(400, 'Invalid cursor', 'InvalidCursor')
+        }
+        query = query.where((eb) =>
+          eb.or([
+            eb('added_at', '>', cursorTs),
+            eb.and([eb('added_at', '=', cursorTs), eb('group_did', '>', cursorDid)]),
+          ]),
+        )
+      }
+
+      const rows = await query.execute()
+
+      const hasMore = rows.length > limit
+      const page = hasMore ? rows.slice(0, limit) : rows
+
+      let nextCursor: string | undefined
+      if (hasMore) {
+        const last = page[page.length - 1]
+        nextCursor = encodeCursor(`${last.added_at}::${last.group_did}`)
+      }
+
+      return jsonResponse({
+        cursor: nextCursor,
+        groups: page.map((m) => ({
+          groupDid: m.group_did,
+          role: m.role,
+          joinedAt: sqliteToIso(m.added_at),
+        })),
+      })
+    },
+  })
+}

--- a/src/api/role/set.ts
+++ b/src/api/role/set.ts
@@ -46,10 +46,8 @@ export default function (server: Server, ctx: AppContext) {
         throw new ForbiddenError('Cannot promote above your own role')
       }
 
-      await groupDb.updateTable('group_members')
-        .set({ role: newRole as Role })
-        .where('member_did', '=', memberDid)
-        .execute()
+      const groupRaw = ctx.groupDbs.getRaw(groupDid)
+      ctx.memberIndex.updateRole(groupRaw, groupDid, memberDid, newRole)
 
       await ctx.audit.log(groupDb, callerDid, 'role.set', 'permitted', {
         memberDid, previousRole: target.role, newRole,

--- a/src/api/role/set.ts
+++ b/src/api/role/set.ts
@@ -30,31 +30,26 @@ export default function (server: Server, ctx: AppContext) {
         throw new XRPCError(404, 'Member not found', 'MemberNotFound')
       }
 
+      // Owner role is immutable via role.set. Each group has exactly one owner
+      // (the registrant). Ownership transfer is a distinct operation that should
+      // be handled separately — it requires additional safeguards (confirmation,
+      // audit trail, potential cooldown) beyond a simple role change.
+      if (target.role === 'owner') {
+        throw new XRPCError(400, 'Cannot change the owner role — use ownership transfer instead', 'CannotModifyOwner')
+      }
+      if (newRole === 'owner') {
+        throw new XRPCError(400, 'Cannot promote to owner — use ownership transfer instead', 'CannotPromoteToOwner')
+      }
+
       // Cannot promote above own role
       if (ROLE_HIERARCHY[callerRole] < ROLE_HIERARCHY[newRole as Role]) {
         throw new ForbiddenError('Cannot promote above your own role')
       }
 
-      // All updates run inside a transaction. For owner demotions the count check
-      // and UPDATE are atomic together, preventing TOCTOU races where two
-      // concurrent demotions both pass the guard.
-      await groupDb.transaction().execute(async (trx) => {
-        if (target.role === 'owner' && newRole !== 'owner') {
-          const ownerCount = await trx
-            .selectFrom('group_members')
-            .where('role', '=', 'owner')
-            .select(trx.fn.countAll().as('count'))
-            .executeTakeFirstOrThrow()
-          if (Number(ownerCount.count) <= 1) {
-            throw new XRPCError(400,
-              'Cannot demote the last owner — promote a replacement first', 'LastOwnerDemotion')
-          }
-        }
-        await trx.updateTable('group_members')
-          .set({ role: newRole as Role })
-          .where('member_did', '=', memberDid)
-          .execute()
-      })
+      await groupDb.updateTable('group_members')
+        .set({ role: newRole as Role })
+        .where('member_did', '=', memberDid)
+        .execute()
 
       await ctx.audit.log(groupDb, callerDid, 'role.set', 'permitted', {
         memberDid, previousRole: target.role, newRole,

--- a/src/auth/verifier.ts
+++ b/src/auth/verifier.ts
@@ -11,6 +11,11 @@ export interface GroupAuthCredentials {
 }
 export type GroupAuthResult = { credentials: GroupAuthCredentials }
 
+export interface ServiceAuthCredentials {
+  callerDid: string
+}
+export type ServiceAuthResult = { credentials: ServiceAuthCredentials }
+
 const REGISTER_NSID = 'app.certified.group.register'
 
 export class AuthVerifier {
@@ -128,6 +133,53 @@ export class AuthVerifier {
       const { iss, aud } = await this.verify(req)
       return {
         credentials: { callerDid: iss, groupDid: aud },
+      }
+    }
+  }
+
+  /**
+   * Verify a service auth JWT for service-level (cross-group) endpoints.
+   * Audience must be this service's DID rather than a specific group DID.
+   */
+  async verifyServiceAuth(req: Request): Promise<{ iss: string }> {
+    const authHeader = req.headers.authorization
+    if (!authHeader?.startsWith('Bearer ')) {
+      throw new AuthRequiredError('Missing auth token')
+    }
+    const jwtStr = authHeader.slice(7)
+    const nsid = this.parseReqNsidFn(req)
+
+    const payload = await this.verifyJwtFn(
+      jwtStr,
+      this.serviceDid,
+      nsid,
+      async (did: string, forceRefresh: boolean): Promise<string> => {
+        const atprotoData = await this.idResolver.did.resolveAtprotoData(
+          did,
+          forceRefresh,
+        )
+        return atprotoData.signingKey
+      },
+    )
+
+    this.assertTokenLifetime(payload)
+
+    if (!payload.jti) {
+      throw new AuthRequiredError('Missing jti in service auth token')
+    }
+    const isNew = await this.nonceCache.checkAndStore(payload.jti)
+    if (!isNew) {
+      throw new AuthRequiredError('Replayed token')
+    }
+
+    return { iss: payload.iss }
+  }
+
+  xrpcServiceAuth(): MethodAuthVerifier<ServiceAuthResult> {
+    return async ({ req }) => {
+      const { iss } = await this.verifyServiceAuth(req)
+      return {
+        credentials: { callerDid: iss },
       }
     }
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -7,14 +7,17 @@ import type { AuthVerifier } from './auth/verifier.js'
 import type { RbacChecker } from './rbac/check.js'
 import type { PdsAgentPool } from './pds/agent.js'
 import type { AuditLogger } from './audit.js'
+import type { MemberIndexWriter } from './db/member-index.js'
 
 export interface AppContext {
   config: Config
   globalDb: Kysely<GlobalDatabase>
+  globalDbPath: string
   groupDbs: GroupDbPool
   authVerifier: AuthVerifier
   rbac: RbacChecker
   pdsAgents: PdsAgentPool
   audit: AuditLogger
+  memberIndex: MemberIndexWriter
   logger: Logger
 }

--- a/src/db/group-db-pool.ts
+++ b/src/db/group-db-pool.ts
@@ -2,12 +2,14 @@ import { join } from 'node:path'
 import { mkdirSync } from 'node:fs'
 import { createHash } from 'node:crypto'
 import { Kysely } from 'kysely'
+import type Database from 'better-sqlite3'
 import type { GroupDatabase } from './schema.js'
 import { runGroupMigrations } from './migrate.js'
 import { openSqliteDb } from './sqlite.js'
 
 export class GroupDbPool {
   private dbs = new Map<string, Kysely<GroupDatabase>>()
+  private rawDbs = new Map<string, Database.Database>()
 
   constructor(private dataDir: string) {
     mkdirSync(dataDir, { recursive: true })
@@ -20,10 +22,17 @@ export class GroupDbPool {
     const safeName = createHash('sha256').update(groupDid).digest('hex')
     const dbPath = join(this.dataDir, `${safeName}.sqlite`)
 
-    const db = openSqliteDb<GroupDatabase>(dbPath)
+    const { db, raw } = openSqliteDb<GroupDatabase>(dbPath)
 
     this.dbs.set(groupDid, db)
+    this.rawDbs.set(groupDid, raw)
     return db
+  }
+
+  getRaw(groupDid: string): Database.Database {
+    // Ensure the DB is opened first
+    this.get(groupDid)
+    return this.rawDbs.get(groupDid)!
   }
 
   async migrateGroup(groupDid: string): Promise<void> {
@@ -34,5 +43,6 @@ export class GroupDbPool {
   async destroyAll(): Promise<void> {
     await Promise.all([...this.dbs.values()].map((db) => db.destroy()))
     this.dbs.clear()
+    this.rawDbs.clear()
   }
 }

--- a/src/db/member-index.ts
+++ b/src/db/member-index.ts
@@ -1,0 +1,96 @@
+import type Database from 'better-sqlite3'
+import type { Kysely } from 'kysely'
+import type { GlobalDatabase } from './schema.js'
+import type { GroupDbPool } from './group-db-pool.js'
+
+export interface MemberIndexWriter {
+  add(groupRaw: Database.Database, groupDid: string, memberDid: string, role: string, addedBy: string): void
+  remove(groupRaw: Database.Database, groupDid: string, memberDid: string): void
+  updateRole(groupRaw: Database.Database, groupDid: string, memberDid: string, newRole: string): void
+}
+
+/** Production: uses ATTACH DATABASE for atomic cross-DB writes. */
+export class MemberIndex implements MemberIndexWriter {
+  constructor(private globalDbPath: string) {}
+
+  add(groupRaw: Database.Database, groupDid: string, memberDid: string, role: string, addedBy: string): void {
+    this.withGlobalAttached(groupRaw, (raw) => {
+      raw.prepare(`INSERT INTO group_members (member_did, role, added_by) VALUES (?, ?, ?)`).run(memberDid, role, addedBy)
+      raw.prepare(`INSERT INTO global_db.member_index (member_did, group_did, role, added_by, added_at) VALUES (?, ?, ?, ?, datetime('now'))`).run(memberDid, groupDid, role, addedBy)
+    })
+  }
+
+  remove(groupRaw: Database.Database, groupDid: string, memberDid: string): void {
+    this.withGlobalAttached(groupRaw, (raw) => {
+      raw.prepare(`DELETE FROM group_members WHERE member_did = ?`).run(memberDid)
+      raw.prepare(`DELETE FROM global_db.member_index WHERE member_did = ? AND group_did = ?`).run(memberDid, groupDid)
+    })
+  }
+
+  updateRole(groupRaw: Database.Database, groupDid: string, memberDid: string, newRole: string): void {
+    this.withGlobalAttached(groupRaw, (raw) => {
+      raw.prepare(`UPDATE group_members SET role = ? WHERE member_did = ?`).run(newRole, memberDid)
+      raw.prepare(`UPDATE global_db.member_index SET role = ? WHERE member_did = ? AND group_did = ?`).run(newRole, memberDid, groupDid)
+    })
+  }
+
+  private withGlobalAttached(groupRaw: Database.Database, fn: (raw: Database.Database) => void): void {
+    groupRaw.exec(`ATTACH DATABASE '${this.globalDbPath}' AS global_db`)
+    try {
+      groupRaw.transaction(() => fn(groupRaw))()
+    } finally {
+      groupRaw.exec('DETACH DATABASE global_db')
+    }
+  }
+}
+
+/** Test: writes sequentially via raw connections (no ATTACH needed for in-memory DBs). */
+export class TestMemberIndex implements MemberIndexWriter {
+  constructor(private globalRaw: Database.Database) {}
+
+  add(groupRaw: Database.Database, groupDid: string, memberDid: string, role: string, addedBy: string): void {
+    groupRaw.prepare(`INSERT INTO group_members (member_did, role, added_by) VALUES (?, ?, ?)`).run(memberDid, role, addedBy)
+    this.globalRaw.prepare(`INSERT INTO member_index (member_did, group_did, role, added_by, added_at) VALUES (?, ?, ?, ?, datetime('now'))`).run(memberDid, groupDid, role, addedBy)
+  }
+
+  remove(groupRaw: Database.Database, groupDid: string, memberDid: string): void {
+    groupRaw.prepare(`DELETE FROM group_members WHERE member_did = ?`).run(memberDid)
+    this.globalRaw.prepare(`DELETE FROM member_index WHERE member_did = ? AND group_did = ?`).run(memberDid, groupDid)
+  }
+
+  updateRole(groupRaw: Database.Database, groupDid: string, memberDid: string, newRole: string): void {
+    groupRaw.prepare(`UPDATE group_members SET role = ? WHERE member_did = ?`).run(newRole, memberDid)
+    this.globalRaw.prepare(`UPDATE member_index SET role = ? WHERE member_did = ? AND group_did = ?`).run(newRole, memberDid, groupDid)
+  }
+}
+
+/** One-time backfill: populates member_index from existing group DBs. Idempotent. */
+export async function backfillMemberIndex(
+  globalDb: Kysely<GlobalDatabase>,
+  groupDbs: GroupDbPool,
+): Promise<number> {
+  const groups = await globalDb.selectFrom('groups').select('did').execute()
+  let count = 0
+  for (const group of groups) {
+    const groupDb = groupDbs.get(group.did)
+    const members = await groupDb
+      .selectFrom('group_members')
+      .select(['member_did', 'role', 'added_by', 'added_at'])
+      .execute()
+    for (const m of members) {
+      await globalDb
+        .insertInto('member_index')
+        .values({
+          member_did: m.member_did,
+          group_did: group.did,
+          role: m.role,
+          added_by: m.added_by,
+          added_at: m.added_at,
+        })
+        .onConflict((oc) => oc.columns(['member_did', 'group_did']).doNothing())
+        .execute()
+      count++
+    }
+  }
+  return count
+}

--- a/src/db/member-index.ts
+++ b/src/db/member-index.ts
@@ -16,7 +16,8 @@ export class MemberIndex implements MemberIndexWriter {
   add(groupRaw: Database.Database, groupDid: string, memberDid: string, role: string, addedBy: string): void {
     this.withGlobalAttached(groupRaw, (raw) => {
       raw.prepare(`INSERT INTO group_members (member_did, role, added_by) VALUES (?, ?, ?)`).run(memberDid, role, addedBy)
-      raw.prepare(`INSERT INTO global_db.member_index (member_did, group_did, role, added_by, added_at) VALUES (?, ?, ?, ?, datetime('now'))`).run(memberDid, groupDid, role, addedBy)
+      const row = raw.prepare(`SELECT added_at FROM group_members WHERE member_did = ?`).get(memberDid) as { added_at: string }
+      raw.prepare(`INSERT INTO global_db.member_index (member_did, group_did, role, added_by, added_at) VALUES (?, ?, ?, ?, ?)`).run(memberDid, groupDid, role, addedBy, row.added_at)
     })
   }
 
@@ -50,7 +51,8 @@ export class TestMemberIndex implements MemberIndexWriter {
 
   add(groupRaw: Database.Database, groupDid: string, memberDid: string, role: string, addedBy: string): void {
     groupRaw.prepare(`INSERT INTO group_members (member_did, role, added_by) VALUES (?, ?, ?)`).run(memberDid, role, addedBy)
-    this.globalRaw.prepare(`INSERT INTO member_index (member_did, group_did, role, added_by, added_at) VALUES (?, ?, ?, ?, datetime('now'))`).run(memberDid, groupDid, role, addedBy)
+    const row = groupRaw.prepare(`SELECT added_at FROM group_members WHERE member_did = ?`).get(memberDid) as { added_at: string }
+    this.globalRaw.prepare(`INSERT INTO member_index (member_did, group_did, role, added_by, added_at) VALUES (?, ?, ?, ?, ?)`).run(memberDid, groupDid, role, addedBy, row.added_at)
   }
 
   remove(groupRaw: Database.Database, groupDid: string, memberDid: string): void {

--- a/src/db/member-index.ts
+++ b/src/db/member-index.ts
@@ -35,7 +35,7 @@ export class MemberIndex implements MemberIndexWriter {
   }
 
   private withGlobalAttached(groupRaw: Database.Database, fn: (raw: Database.Database) => void): void {
-    groupRaw.exec(`ATTACH DATABASE '${this.globalDbPath}' AS global_db`)
+    groupRaw.prepare('ATTACH DATABASE ? AS global_db').run(this.globalDbPath)
     try {
       groupRaw.transaction(() => fn(groupRaw))()
     } finally {
@@ -87,7 +87,13 @@ export async function backfillMemberIndex(
           added_by: m.added_by,
           added_at: m.added_at,
         })
-        .onConflict((oc) => oc.columns(['member_did', 'group_did']).doNothing())
+        .onConflict((oc) =>
+          oc.columns(['member_did', 'group_did']).doUpdateSet({
+            role: m.role,
+            added_by: m.added_by,
+            added_at: m.added_at,
+          }),
+        )
         .execute()
       count++
     }

--- a/src/db/migrations/global/003_member_index.ts
+++ b/src/db/migrations/global/003_member_index.ts
@@ -1,0 +1,25 @@
+import { Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('member_index')
+    .addColumn('member_did', 'text', (col) => col.notNull())
+    .addColumn('group_did', 'text', (col) => col.notNull())
+    .addColumn('role', 'text', (col) => col.notNull())
+    .addColumn('added_by', 'text', (col) => col.notNull())
+    .addColumn('added_at', 'text', (col) =>
+      col.defaultTo(sql`(datetime('now'))`).notNull(),
+    )
+    .addPrimaryKeyConstraint('pk_member_index', ['member_did', 'group_did'])
+    .execute()
+
+  await db.schema
+    .createIndex('idx_member_index_group')
+    .on('member_index')
+    .columns(['group_did'])
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('member_index').ifExists().execute()
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -4,6 +4,7 @@ import type { Generated } from 'kysely'
 export interface GlobalDatabase {
   groups: GroupsTable
   nonce_cache: NonceCacheTable
+  member_index: MemberIndexTable
 }
 
 /** Per-group tables stored in per-group SQLite files */
@@ -29,6 +30,14 @@ interface NonceCacheTable {
 interface GroupMembersTable {
   member_did: string
   role: 'member' | 'admin' | 'owner'
+  added_by: string
+  added_at: Generated<string>
+}
+
+interface MemberIndexTable {
+  member_did: string
+  group_did: string
+  role: string
   added_by: string
   added_at: Generated<string>
 }

--- a/src/db/sqlite.ts
+++ b/src/db/sqlite.ts
@@ -1,11 +1,17 @@
 import Database from 'better-sqlite3'
 import { Kysely, SqliteDialect } from 'kysely'
 
-export function openSqliteDb<T>(path: string): Kysely<T> {
-  const sqliteDb = new Database(path)
-  sqliteDb.pragma('journal_mode = WAL')
-  sqliteDb.pragma('busy_timeout = 5000')
-  return new Kysely<T>({
-    dialect: new SqliteDialect({ database: sqliteDb }),
+export interface SqliteDb<T> {
+  db: Kysely<T>
+  raw: Database.Database
+}
+
+export function openSqliteDb<T>(path: string): SqliteDb<T> {
+  const raw = new Database(path)
+  raw.pragma('journal_mode = WAL')
+  raw.pragma('busy_timeout = 5000')
+  const db = new Kysely<T>({
+    dialect: new SqliteDialect({ database: raw }),
   })
+  return { db, raw }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { createFallbackErrorHandler } from './api/error-handler.js'
 import { runGlobalMigrations } from './db/migrate.js'
 import { openSqliteDb } from './db/sqlite.js'
 import { GroupDbPool } from './db/group-db-pool.js'
+import { MemberIndex, backfillMemberIndex } from './db/member-index.js'
 import { PdsAgentPool } from './pds/agent.js'
 import { AuditLogger } from './audit.js'
 import type { AppContext } from './context.js'
@@ -28,7 +29,8 @@ async function main() {
   mkdirSync(config.dataDir, { recursive: true })
 
   // Global SQLite database
-  const globalDb = openSqliteDb<GlobalDatabase>(join(config.dataDir, 'global.sqlite'))
+  const globalDbPath = join(config.dataDir, 'global.sqlite')
+  const { db: globalDb } = openSqliteDb<GlobalDatabase>(globalDbPath)
 
   await runGlobalMigrations(globalDb)
   logger.info('Global migrations complete')
@@ -45,6 +47,10 @@ async function main() {
 
   await Promise.all(groups.map((group) => groupDbs.migrateGroup(group.did)))
   logger.info({ groups: groups.length }, 'Per-group databases initialized')
+
+  // Backfill member_index from existing group DBs (idempotent)
+  const backfilled = await backfillMemberIndex(globalDb, groupDbs)
+  logger.info({ backfilled }, 'Member index backfill complete')
 
   // Auth & RBAC
   const nonceCache = new NonceCache(globalDb)
@@ -63,8 +69,9 @@ async function main() {
   // XRPC routes
   const pdsAgents = new PdsAgentPool(globalDb, Buffer.from(config.encryptionKey, 'hex'))
   const audit = new AuditLogger()
+  const memberIndex = new MemberIndex(globalDbPath)
   const ctx: AppContext = {
-    config, globalDb, groupDbs, authVerifier, rbac, pdsAgents, audit, logger,
+    config, globalDb, globalDbPath, groupDbs, authVerifier, rbac, pdsAgents, audit, memberIndex, logger,
   }
 
   // Health check (unchanged)

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -9,7 +9,8 @@ describe('AuditLogger', () => {
   let audit: AuditLogger
 
   beforeEach(async () => {
-    groupDb = await createTestGroupDb()
+    const testGroup = await createTestGroupDb()
+    groupDb = testGroup.db
     audit = new AuditLogger()
   })
 

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -9,7 +9,8 @@ describe('NonceCache', () => {
   let cache: NonceCache
 
   beforeEach(async () => {
-    db = await createTestGlobalDb()
+    const testGlobal = await createTestGlobalDb()
+    db = testGlobal.db
     cache = new NonceCache(db)
   })
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -22,21 +22,21 @@ describe('openSqliteDb', () => {
   })
 
   it('returns usable Kysely instance', async () => {
-    const db = openSqliteDb(join(tmpDir, 'test.sqlite'))
+    const { db } = openSqliteDb(join(tmpDir, 'test.sqlite'))
     const result = await sql<{ val: number }>`SELECT 1 as val`.execute(db)
     expect(result.rows).toHaveLength(1)
     await db.destroy()
   })
 
   it('sets WAL journal mode', async () => {
-    const db = openSqliteDb(join(tmpDir, 'test.sqlite'))
+    const { db } = openSqliteDb(join(tmpDir, 'test.sqlite'))
     const result = await sql<{ journal_mode: string }>`PRAGMA journal_mode`.execute(db)
     expect(result.rows[0].journal_mode).toBe('wal')
     await db.destroy()
   })
 
   it('sets busy_timeout to 5000', async () => {
-    const db = openSqliteDb(join(tmpDir, 'test.sqlite'))
+    const { db } = openSqliteDb(join(tmpDir, 'test.sqlite'))
     const result = await sql<{ timeout: number }>`PRAGMA busy_timeout`.execute(db)
     expect(result.rows[0].timeout).toBe(5000)
     await db.destroy()
@@ -101,14 +101,14 @@ describe('GroupDbPool', () => {
 
 describe('migrations', () => {
   it('global migrations create groups and nonce_cache tables', async () => {
-    const db = await createTestGlobalDb()
+    const { db } = await createTestGlobalDb()
     await db.selectFrom('groups').selectAll().execute()
     await db.selectFrom('nonce_cache').selectAll().execute()
     await db.destroy()
   })
 
   it('group migrations create group_members, group_record_authors, group_audit_log', async () => {
-    const db = await createTestGroupDb()
+    const { db } = await createTestGroupDb()
     await db.selectFrom('group_members').selectAll().execute()
     await db.selectFrom('group_record_authors').selectAll().execute()
     await db.selectFrom('group_audit_log').selectAll().execute()
@@ -116,12 +116,12 @@ describe('migrations', () => {
   })
 
   it('migrations are idempotent', async () => {
-    const db = await createTestGlobalDb()
+    const { db } = await createTestGlobalDb()
     await runGlobalMigrations(db)
     await db.selectFrom('groups').selectAll().execute()
     await db.destroy()
 
-    const db2 = await createTestGroupDb()
+    const { db: db2 } = await createTestGroupDb()
     await runGroupMigrations(db2)
     await db2.selectFrom('group_members').selectAll().execute()
     await db2.destroy()

--- a/tests/groups-membership.test.ts
+++ b/tests/groups-membership.test.ts
@@ -160,4 +160,103 @@ describe('groups.membership.list', () => {
     const joinedAt = res.body.groups[0].joinedAt
     expect(new Date(joinedAt).toISOString()).toBe(joinedAt)
   })
+
+  it('paginates correctly when added_at timestamps are identical', async () => {
+    const timestamp = '2025-01-01 00:00:00'
+    const dids = ['did:plc:aaa', 'did:plc:bbb', 'did:plc:ccc', 'did:plc:ddd']
+
+    // Register groups in global DB
+    for (const did of dids) {
+      await globalDb.insertInto('groups').values({
+        did,
+        pds_url: 'https://pds.example.com',
+        encrypted_app_password: 'enc',
+      }).execute()
+    }
+
+    // Insert directly into member_index with identical timestamps
+    for (const did of dids) {
+      await globalDb.insertInto('member_index').values({
+        member_did: 'did:plc:testuser',
+        group_did: did,
+        role: 'member',
+        added_by: 'did:plc:owner',
+        added_at: timestamp,
+      }).execute()
+    }
+
+    const res1 = await request(app).get('/xrpc/app.certified.groups.membership.list?limit=2')
+    expect(res1.status).toBe(200)
+    expect(res1.body.groups).toHaveLength(2)
+    expect(res1.body.cursor).toBeDefined()
+
+    const res2 = await request(app).get(
+      `/xrpc/app.certified.groups.membership.list?limit=2&cursor=${res1.body.cursor}`,
+    )
+    expect(res2.status).toBe(200)
+    expect(res2.body.groups).toHaveLength(2)
+    expect(res2.body.cursor).toBeUndefined()
+
+    // Verify all 4 DIDs returned with no duplicates
+    const allDids = [
+      ...res1.body.groups.map((g: any) => g.groupDid),
+      ...res2.body.groups.map((g: any) => g.groupDid),
+    ]
+    expect(allDids).toEqual(dids) // lexicographic order
+    expect(new Set(allDids).size).toBe(4)
+  })
+
+  it('multi-page pagination returns all results without duplicates', async () => {
+    // Register 7 groups
+    const groupDids = Array.from({ length: 7 }, (_, i) => `did:plc:page${i}`)
+    for (const did of groupDids) {
+      await globalDb.insertInto('groups').values({
+        did,
+        pds_url: 'https://pds.example.com',
+        encrypted_app_password: 'enc',
+      }).execute()
+    }
+
+    // Insert into member_index with ascending timestamps
+    for (let i = 0; i < 7; i++) {
+      await globalDb.insertInto('member_index').values({
+        member_did: 'did:plc:testuser',
+        group_did: groupDids[i],
+        role: 'member',
+        added_by: 'did:plc:owner',
+        added_at: `2025-01-01 00:00:0${i + 1}`,
+      }).execute()
+    }
+
+    // Page 1
+    const res1 = await request(app).get('/xrpc/app.certified.groups.membership.list?limit=3')
+    expect(res1.status).toBe(200)
+    expect(res1.body.groups).toHaveLength(3)
+    expect(res1.body.cursor).toBeDefined()
+
+    // Page 2
+    const res2 = await request(app).get(
+      `/xrpc/app.certified.groups.membership.list?limit=3&cursor=${res1.body.cursor}`,
+    )
+    expect(res2.status).toBe(200)
+    expect(res2.body.groups).toHaveLength(3)
+    expect(res2.body.cursor).toBeDefined()
+
+    // Page 3
+    const res3 = await request(app).get(
+      `/xrpc/app.certified.groups.membership.list?limit=3&cursor=${res2.body.cursor}`,
+    )
+    expect(res3.status).toBe(200)
+    expect(res3.body.groups).toHaveLength(1)
+    expect(res3.body.cursor).toBeUndefined()
+
+    // Verify union of all pages
+    const allDids = [
+      ...res1.body.groups.map((g: any) => g.groupDid),
+      ...res2.body.groups.map((g: any) => g.groupDid),
+      ...res3.body.groups.map((g: any) => g.groupDid),
+    ]
+    expect(new Set(allDids).size).toBe(7)
+    expect(new Set(allDids)).toEqual(new Set(groupDids))
+  })
 })

--- a/tests/groups-membership.test.ts
+++ b/tests/groups-membership.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { createTestContext, seedMemberWithIndex, createTestApp, mockAuth } from './helpers/mock-server.js'
+import { createTestGroupDb } from './helpers/test-db.js'
+import membershipListHandler from '../src/api/membership/list.js'
+import type { AppContext } from '../src/context.js'
+import type { Kysely } from 'kysely'
+import type { GlobalDatabase, GroupDatabase } from '../src/db/schema.js'
+
+function buildApp(ctx: AppContext) {
+  return createTestApp(ctx, (server, appCtx) => {
+    membershipListHandler(server, appCtx)
+  })
+}
+
+describe('groups.membership.list', () => {
+  let ctx: AppContext
+  let globalDb: Kysely<GlobalDatabase>
+  let groupDbA: Kysely<GroupDatabase>
+  let groupDbB: Kysely<GroupDatabase>
+  let groupDbC: Kysely<GroupDatabase>
+  let app: express.Express
+
+  beforeEach(async () => {
+    const test = await createTestContext()
+    ctx = test.ctx
+    globalDb = test.globalDb
+
+    // Create multiple group databases
+    const testA = await createTestGroupDb()
+    const testB = await createTestGroupDb()
+    const testC = await createTestGroupDb()
+    groupDbA = testA.db
+    groupDbB = testB.db
+    groupDbC = testC.db
+
+    // Register groups in global DB
+    await globalDb.insertInto('groups').values({
+      did: 'did:plc:groupA',
+      pds_url: 'https://pds.example.com',
+      encrypted_app_password: 'enc_pass_a',
+    }).execute()
+    await globalDb.insertInto('groups').values({
+      did: 'did:plc:groupB',
+      pds_url: 'https://pds.example.com',
+      encrypted_app_password: 'enc_pass_b',
+    }).execute()
+    await globalDb.insertInto('groups').values({
+      did: 'did:plc:groupC',
+      pds_url: 'https://pds.example.com',
+      encrypted_app_password: 'enc_pass_c',
+    }).execute()
+
+    app = buildApp(ctx)
+  })
+
+  afterEach(async () => {
+    await groupDbA.destroy()
+    await groupDbB.destroy()
+    await groupDbC.destroy()
+    await globalDb.destroy()
+  })
+
+  it('returns empty list when user is not a member of any group', async () => {
+    const res = await request(app).get('/xrpc/app.certified.groups.membership.list')
+    expect(res.status).toBe(200)
+    expect(res.body.groups).toEqual([])
+  })
+
+  it('returns groups the user belongs to', async () => {
+    await seedMemberWithIndex(groupDbA, globalDb, 'did:plc:testuser', 'did:plc:groupA', 'member')
+    await seedMemberWithIndex(groupDbB, globalDb, 'did:plc:testuser', 'did:plc:groupB', 'admin')
+
+    const res = await request(app).get('/xrpc/app.certified.groups.membership.list')
+    expect(res.status).toBe(200)
+    expect(res.body.groups).toHaveLength(2)
+
+    const dids = res.body.groups.map((g: any) => g.groupDid)
+    expect(dids).toContain('did:plc:groupA')
+    expect(dids).toContain('did:plc:groupB')
+
+    const groupA = res.body.groups.find((g: any) => g.groupDid === 'did:plc:groupA')
+    expect(groupA.role).toBe('member')
+    expect(groupA.joinedAt).toBeDefined()
+
+    const groupB = res.body.groups.find((g: any) => g.groupDid === 'did:plc:groupB')
+    expect(groupB.role).toBe('admin')
+  })
+
+  it('does not include groups the user is not a member of', async () => {
+    await seedMemberWithIndex(groupDbA, globalDb, 'did:plc:testuser', 'did:plc:groupA', 'member')
+    await seedMemberWithIndex(groupDbC, globalDb, 'did:plc:otheruser', 'did:plc:groupC', 'member')
+
+    const res = await request(app).get('/xrpc/app.certified.groups.membership.list')
+    expect(res.status).toBe(200)
+    expect(res.body.groups).toHaveLength(1)
+    expect(res.body.groups[0].groupDid).toBe('did:plc:groupA')
+  })
+
+  it('returns owner role correctly', async () => {
+    await seedMemberWithIndex(groupDbA, globalDb, 'did:plc:testuser', 'did:plc:groupA', 'owner')
+
+    const res = await request(app).get('/xrpc/app.certified.groups.membership.list')
+    expect(res.status).toBe(200)
+    expect(res.body.groups).toHaveLength(1)
+    expect(res.body.groups[0].role).toBe('owner')
+  })
+
+  it('paginates with cursor', async () => {
+    // Add user to all three groups
+    await seedMemberWithIndex(groupDbA, globalDb, 'did:plc:testuser', 'did:plc:groupA', 'member')
+    await seedMemberWithIndex(groupDbB, globalDb, 'did:plc:testuser', 'did:plc:groupB', 'admin')
+    await seedMemberWithIndex(groupDbC, globalDb, 'did:plc:testuser', 'did:plc:groupC', 'owner')
+
+    const res1 = await request(app).get('/xrpc/app.certified.groups.membership.list?limit=2')
+    expect(res1.status).toBe(200)
+    expect(res1.body.groups).toHaveLength(2)
+    expect(res1.body.cursor).toBeDefined()
+
+    const res2 = await request(app).get(
+      `/xrpc/app.certified.groups.membership.list?limit=2&cursor=${res1.body.cursor}`,
+    )
+    expect(res2.status).toBe(200)
+    expect(res2.body.groups).toHaveLength(1)
+    expect(res2.body.cursor).toBeUndefined()
+
+    // Verify no duplicates across pages
+    const allDids = [
+      ...res1.body.groups.map((g: any) => g.groupDid),
+      ...res2.body.groups.map((g: any) => g.groupDid),
+    ]
+    expect(new Set(allDids).size).toBe(3)
+  })
+
+  it('invalid cursor returns 400 InvalidCursor', async () => {
+    const badCursor = Buffer.from('bad').toString('base64')
+    const res = await request(app).get(
+      `/xrpc/app.certified.groups.membership.list?cursor=${badCursor}`,
+    )
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('InvalidCursor')
+  })
+
+  it('limit=0 is rejected', async () => {
+    const res = await request(app).get('/xrpc/app.certified.groups.membership.list?limit=0')
+    expect(res.status).toBe(400)
+  })
+
+  it('limit exceeding maximum is rejected', async () => {
+    const res = await request(app).get('/xrpc/app.certified.groups.membership.list?limit=999')
+    expect(res.status).toBe(400)
+  })
+
+  it('joinedAt is a valid ISO datetime', async () => {
+    await seedMemberWithIndex(groupDbA, globalDb, 'did:plc:testuser', 'did:plc:groupA', 'member')
+
+    const res = await request(app).get('/xrpc/app.certified.groups.membership.list')
+    expect(res.status).toBe(200)
+    const joinedAt = res.body.groups[0].joinedAt
+    expect(new Date(joinedAt).toISOString()).toBe(joinedAt)
+  })
+})

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -10,7 +10,8 @@ describe('GET /health', () => {
   let app: express.Express
 
   beforeEach(async () => {
-    globalDb = await createTestGlobalDb()
+    const testGlobal = await createTestGlobalDb()
+    globalDb = testGlobal.db
     app = express()
     app.get('/health', async (_req, res) => {
       try {

--- a/tests/helpers/mock-server.ts
+++ b/tests/helpers/mock-server.ts
@@ -1,7 +1,9 @@
+import type Database from 'better-sqlite3'
 import type { AppContext } from '../../src/context.js'
 import type { Config } from '../../src/config.js'
 import { RbacChecker } from '../../src/rbac/check.js'
 import { AuditLogger } from '../../src/audit.js'
+import { TestMemberIndex } from '../../src/db/member-index.js'
 import { createTestGlobalDb, createTestGroupDb } from './test-db.js'
 import type { Kysely } from 'kysely'
 import type { GlobalDatabase, GroupDatabase } from '../../src/db/schema.js'
@@ -18,10 +20,12 @@ const LEXICON_DIR = join(__dirname, '../../lexicons')
 export async function createTestContext(overrides?: Partial<AppContext>): Promise<{
   ctx: AppContext
   globalDb: Kysely<GlobalDatabase>
+  globalRaw: Database.Database
   groupDb: Kysely<GroupDatabase>
+  groupRaw: Database.Database
 }> {
-  const globalDb = await createTestGlobalDb()
-  const groupDb = await createTestGroupDb()
+  const { db: globalDb, raw: globalRaw } = await createTestGlobalDb()
+  const { db: groupDb, raw: groupRaw } = await createTestGroupDb()
 
   const mockConfig: Config = {
     port: 3000,
@@ -38,6 +42,7 @@ export async function createTestContext(overrides?: Partial<AppContext>): Promis
 
   const mockGroupDbs = {
     get: () => groupDb,
+    getRaw: () => groupRaw,
     migrateGroup: async () => {},
     destroyAll: async () => {},
   }
@@ -68,19 +73,23 @@ export async function createTestContext(overrides?: Partial<AppContext>): Promis
     invalidate: () => {},
   }
 
+  const memberIndex = new TestMemberIndex(globalRaw)
+
   const ctx: AppContext = {
     config: mockConfig,
     globalDb,
+    globalDbPath: ':memory:',
     groupDbs: mockGroupDbs as any,
     authVerifier: mockAuth('did:plc:testuser'),
     rbac: new RbacChecker(),
     pdsAgents: mockPdsAgents as any,
     audit: new AuditLogger(),
+    memberIndex,
     logger: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} } as any,
     ...overrides,
   }
 
-  return { ctx, globalDb, groupDb }
+  return { ctx, globalDb, globalRaw, groupDb, groupRaw }
 }
 
 export const silentLogger = { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} }
@@ -97,6 +106,40 @@ export async function seedMember(
       member_did: memberDid,
       role,
       added_by: addedBy,
+    })
+    .execute()
+}
+
+export async function seedMemberWithIndex(
+  groupDb: Kysely<GroupDatabase>,
+  globalDb: Kysely<GlobalDatabase>,
+  memberDid: string,
+  groupDid: string,
+  role: string,
+  addedBy = 'did:plc:owner',
+): Promise<void> {
+  await groupDb
+    .insertInto('group_members')
+    .values({
+      member_did: memberDid,
+      role,
+      added_by: addedBy,
+    })
+    .execute()
+  // Read back added_at from group DB to keep index in sync
+  const row = await groupDb
+    .selectFrom('group_members')
+    .select('added_at')
+    .where('member_did', '=', memberDid)
+    .executeTakeFirstOrThrow()
+  await globalDb
+    .insertInto('member_index')
+    .values({
+      member_did: memberDid,
+      group_did: groupDid,
+      role,
+      added_by: addedBy,
+      added_at: row.added_at,
     })
     .execute()
 }
@@ -134,10 +177,16 @@ export function mockAuth(iss: string, aud: string = 'did:plc:testgroup') {
   return {
     verify: async () => ({ iss, aud }),
     verifyRegistration: async () => ({ iss }),
+    verifyServiceAuth: async () => ({ iss }),
     xrpcAuth() {
       return async ({ req }: { req: any }) => {
         const { iss, aud } = await this.verify(req)
         return { credentials: { callerDid: iss, groupDid: aud } }
+      }
+    },
+    xrpcServiceAuth() {
+      return async () => {
+        return { credentials: { callerDid: iss } }
       }
     },
   } as any

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -3,20 +3,20 @@ import { Kysely, SqliteDialect } from 'kysely'
 import { runGlobalMigrations, runGroupMigrations } from '../../src/db/migrate.js'
 import type { GlobalDatabase, GroupDatabase } from '../../src/db/schema.js'
 
-export async function createTestGlobalDb(): Promise<Kysely<GlobalDatabase>> {
-  const sqliteDb = new Database(':memory:')
+export async function createTestGlobalDb(): Promise<{ db: Kysely<GlobalDatabase>; raw: Database.Database }> {
+  const raw = new Database(':memory:')
   const db = new Kysely<GlobalDatabase>({
-    dialect: new SqliteDialect({ database: sqliteDb }),
+    dialect: new SqliteDialect({ database: raw }),
   })
   await runGlobalMigrations(db)
-  return db
+  return { db, raw }
 }
 
-export async function createTestGroupDb(): Promise<Kysely<GroupDatabase>> {
-  const sqliteDb = new Database(':memory:')
+export async function createTestGroupDb(): Promise<{ db: Kysely<GroupDatabase>; raw: Database.Database }> {
+  const raw = new Database(':memory:')
   const db = new Kysely<GroupDatabase>({
-    dialect: new SqliteDialect({ database: sqliteDb }),
+    dialect: new SqliteDialect({ database: raw }),
   })
   await runGroupMigrations(db)
-  return db
+  return { db, raw }
 }

--- a/tests/member-index-attach.test.ts
+++ b/tests/member-index-attach.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { Kysely, SqliteDialect } from 'kysely'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { MemberIndex } from '../src/db/member-index.js'
+import { runGlobalMigrations, runGroupMigrations } from '../src/db/migrate.js'
+import type { GlobalDatabase, GroupDatabase } from '../src/db/schema.js'
+
+describe('MemberIndex (ATTACH DATABASE)', () => {
+  let tmpDir: string
+  let globalDbPath: string
+  let groupDbPath: string
+  let globalRaw: Database.Database
+  let groupRaw: Database.Database
+  let globalDb: Kysely<GlobalDatabase>
+  let groupDb: Kysely<GroupDatabase>
+  let memberIndex: MemberIndex
+
+  const groupDid = 'did:plc:testgroup'
+  const memberDid = 'did:plc:alice'
+  const addedBy = 'did:plc:owner'
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'member-index-test-'))
+    globalDbPath = join(tmpDir, 'global.sqlite')
+    groupDbPath = join(tmpDir, 'group.sqlite')
+
+    globalRaw = new Database(globalDbPath)
+    groupRaw = new Database(groupDbPath)
+
+    globalDb = new Kysely<GlobalDatabase>({
+      dialect: new SqliteDialect({ database: globalRaw }),
+    })
+    groupDb = new Kysely<GroupDatabase>({
+      dialect: new SqliteDialect({ database: groupRaw }),
+    })
+
+    await runGlobalMigrations(globalDb)
+    await runGroupMigrations(groupDb)
+
+    memberIndex = new MemberIndex(globalDbPath)
+  })
+
+  afterEach(() => {
+    globalRaw.close()
+    groupRaw.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('add() writes to both group_members and member_index', async () => {
+    memberIndex.add(groupRaw, groupDid, memberDid, 'member', addedBy)
+
+    const groupRow = await groupDb
+      .selectFrom('group_members')
+      .selectAll()
+      .where('member_did', '=', memberDid)
+      .executeTakeFirst()
+    expect(groupRow).toBeDefined()
+    expect(groupRow!.role).toBe('member')
+
+    const indexRow = await globalDb
+      .selectFrom('member_index')
+      .selectAll()
+      .where('member_did', '=', memberDid)
+      .where('group_did', '=', groupDid)
+      .executeTakeFirst()
+    expect(indexRow).toBeDefined()
+    expect(indexRow!.role).toBe('member')
+    expect(indexRow!.added_by).toBe(addedBy)
+  })
+
+  it('remove() deletes from both tables', async () => {
+    memberIndex.add(groupRaw, groupDid, memberDid, 'member', addedBy)
+    memberIndex.remove(groupRaw, groupDid, memberDid)
+
+    const groupRow = await groupDb
+      .selectFrom('group_members')
+      .selectAll()
+      .where('member_did', '=', memberDid)
+      .executeTakeFirst()
+    expect(groupRow).toBeUndefined()
+
+    const indexRow = await globalDb
+      .selectFrom('member_index')
+      .selectAll()
+      .where('member_did', '=', memberDid)
+      .where('group_did', '=', groupDid)
+      .executeTakeFirst()
+    expect(indexRow).toBeUndefined()
+  })
+
+  it('updateRole() updates both tables', async () => {
+    memberIndex.add(groupRaw, groupDid, memberDid, 'member', addedBy)
+    memberIndex.updateRole(groupRaw, groupDid, memberDid, 'admin')
+
+    const groupRow = await groupDb
+      .selectFrom('group_members')
+      .selectAll()
+      .where('member_did', '=', memberDid)
+      .executeTakeFirst()
+    expect(groupRow!.role).toBe('admin')
+
+    const indexRow = await globalDb
+      .selectFrom('member_index')
+      .selectAll()
+      .where('member_did', '=', memberDid)
+      .where('group_did', '=', groupDid)
+      .executeTakeFirst()
+    expect(indexRow!.role).toBe('admin')
+  })
+
+  it('add() rolls back group_members on member_index PK violation', async () => {
+    memberIndex.add(groupRaw, groupDid, memberDid, 'member', addedBy)
+
+    // Pre-insert a different member in group_members to ensure add() would insert
+    // a new group_members row, but the member_index PK (member_did, group_did) already
+    // exists — so the transaction should roll back both writes.
+    const otherMember = 'did:plc:bob'
+
+    // First, insert into member_index directly to create PK conflict
+    globalRaw.prepare(
+      `INSERT INTO member_index (member_did, group_did, role, added_by, added_at) VALUES (?, ?, ?, ?, datetime('now'))`,
+    ).run(otherMember, groupDid, 'member', addedBy)
+
+    // Now try add() which will try to insert into group_members AND member_index.
+    // member_index insert should fail (PK violation), rolling back group_members too.
+    expect(() => {
+      memberIndex.add(groupRaw, groupDid, otherMember, 'member', addedBy)
+    }).toThrow()
+
+    // group_members should NOT have the row (rolled back)
+    const groupRow = await groupDb
+      .selectFrom('group_members')
+      .selectAll()
+      .where('member_did', '=', otherMember)
+      .executeTakeFirst()
+    expect(groupRow).toBeUndefined()
+  })
+
+  it('DETACH runs even on error — group DB remains usable', async () => {
+    // Cause a failure by inserting a duplicate
+    memberIndex.add(groupRaw, groupDid, memberDid, 'member', addedBy)
+    expect(() => {
+      memberIndex.add(groupRaw, groupDid, memberDid, 'member', addedBy)
+    }).toThrow()
+
+    // Group DB should still be usable (no stale ATTACH)
+    const rows = await groupDb
+      .selectFrom('group_members')
+      .selectAll()
+      .execute()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].member_did).toBe(memberDid)
+  })
+})

--- a/tests/member-index.test.ts
+++ b/tests/member-index.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import request from 'supertest'
+import type express from 'express'
+import type { Kysely } from 'kysely'
+import type { AppContext } from '../src/context.js'
+import type { GlobalDatabase, GroupDatabase } from '../src/db/schema.js'
+import { createTestContext, seedMember, seedMemberWithIndex, createTestApp, mockAuth } from './helpers/mock-server.js'
+import { createTestGroupDb } from './helpers/test-db.js'
+import memberAddHandler from '../src/api/member/add.js'
+import memberRemoveHandler from '../src/api/member/remove.js'
+import roleSetHandler from '../src/api/role/set.js'
+import membershipListHandler from '../src/api/membership/list.js'
+import { backfillMemberIndex } from '../src/db/member-index.js'
+
+function buildApp(ctx: AppContext) {
+  return createTestApp(ctx, (server, appCtx) => {
+    memberAddHandler(server, appCtx)
+    memberRemoveHandler(server, appCtx)
+    roleSetHandler(server, appCtx)
+    membershipListHandler(server, appCtx)
+  })
+}
+
+describe('member_index round-trip', () => {
+  let ctx: AppContext
+  let globalDb: Kysely<GlobalDatabase>
+  let groupDb: Kysely<GroupDatabase>
+  let app: express.Express
+
+  const ownerDid = 'did:plc:testuser'
+  const groupDid = 'did:plc:testgroup'
+  const memberDid = 'did:plc:newmember'
+
+  beforeEach(async () => {
+    const test = await createTestContext()
+    ctx = test.ctx
+    globalDb = test.globalDb
+    groupDb = test.groupDb
+
+    // Seed the caller as owner so they can perform all mutations
+    await seedMemberWithIndex(groupDb, globalDb, ownerDid, groupDid, 'owner')
+
+    app = buildApp(ctx)
+  })
+
+  afterEach(async () => {
+    await groupDb.destroy()
+    await globalDb.destroy()
+  })
+
+  it('member.add appears in membership.list', async () => {
+    // Add a member via handler
+    const addRes = await request(app)
+      .post('/xrpc/app.certified.group.member.add')
+      .send({ memberDid, role: 'member' })
+    expect(addRes.status).toBe(200)
+
+    // Query membership.list as that member
+    const memberApp = buildApp({ ...ctx, authVerifier: mockAuth(memberDid) })
+    const listRes = await request(memberApp)
+      .get('/xrpc/app.certified.groups.membership.list')
+    expect(listRes.status).toBe(200)
+    expect(listRes.body.groups).toHaveLength(1)
+    expect(listRes.body.groups[0].groupDid).toBe(groupDid)
+    expect(listRes.body.groups[0].role).toBe('member')
+  })
+
+  it('member.remove disappears from membership.list', async () => {
+    // Add then remove
+    await request(app)
+      .post('/xrpc/app.certified.group.member.add')
+      .send({ memberDid, role: 'member' })
+
+    const removeRes = await request(app)
+      .post('/xrpc/app.certified.group.member.remove')
+      .send({ memberDid })
+    expect(removeRes.status).toBe(200)
+
+    // membership.list should be empty for that member
+    const memberApp = buildApp({ ...ctx, authVerifier: mockAuth(memberDid) })
+    const listRes = await request(memberApp)
+      .get('/xrpc/app.certified.groups.membership.list')
+    expect(listRes.status).toBe(200)
+    expect(listRes.body.groups).toEqual([])
+  })
+
+  it('role.set updates membership.list', async () => {
+    // Add as member
+    await request(app)
+      .post('/xrpc/app.certified.group.member.add')
+      .send({ memberDid, role: 'member' })
+
+    // Promote to admin
+    const setRes = await request(app)
+      .post('/xrpc/app.certified.group.role.set')
+      .send({ memberDid, role: 'admin' })
+    expect(setRes.status).toBe(200)
+
+    // membership.list should reflect admin
+    const memberApp = buildApp({ ...ctx, authVerifier: mockAuth(memberDid) })
+    const listRes = await request(memberApp)
+      .get('/xrpc/app.certified.groups.membership.list')
+    expect(listRes.status).toBe(200)
+    expect(listRes.body.groups).toHaveLength(1)
+    expect(listRes.body.groups[0].role).toBe('admin')
+  })
+
+  it('group_members and member_index stay in sync', async () => {
+    await request(app)
+      .post('/xrpc/app.certified.group.member.add')
+      .send({ memberDid, role: 'member' })
+
+    const groupRow = await groupDb
+      .selectFrom('group_members')
+      .selectAll()
+      .where('member_did', '=', memberDid)
+      .executeTakeFirst()
+
+    const indexRow = await globalDb
+      .selectFrom('member_index')
+      .selectAll()
+      .where('member_did', '=', memberDid)
+      .where('group_did', '=', groupDid)
+      .executeTakeFirst()
+
+    expect(groupRow).toBeDefined()
+    expect(indexRow).toBeDefined()
+    expect(groupRow!.role).toBe(indexRow!.role)
+    expect(groupRow!.added_by).toBe(indexRow!.added_by)
+    expect(groupRow!.added_at).toBe(indexRow!.added_at)
+  })
+})
+
+describe('backfillMemberIndex', () => {
+  let globalDb: Kysely<GlobalDatabase>
+  let groupDbA: Kysely<GroupDatabase>
+  let groupDbB: Kysely<GroupDatabase>
+
+  const groupADid = 'did:plc:groupA'
+  const groupBDid = 'did:plc:groupB'
+
+  beforeEach(async () => {
+    const test = await createTestContext()
+    globalDb = test.globalDb
+
+    const testA = await createTestGroupDb()
+    const testB = await createTestGroupDb()
+    groupDbA = testA.db
+    groupDbB = testB.db
+
+    // Register groups in global DB
+    await globalDb.insertInto('groups').values({
+      did: groupADid,
+      pds_url: 'https://pds.example.com',
+      encrypted_app_password: 'enc_a',
+    }).execute()
+    await globalDb.insertInto('groups').values({
+      did: groupBDid,
+      pds_url: 'https://pds.example.com',
+      encrypted_app_password: 'enc_b',
+    }).execute()
+
+    // Seed members in group DBs only (no index)
+    await seedMember(groupDbA, 'did:plc:alice', 'owner')
+    await seedMember(groupDbA, 'did:plc:bob', 'admin')
+    await seedMember(groupDbB, 'did:plc:alice', 'member')
+    await seedMember(groupDbB, 'did:plc:carol', 'member')
+  })
+
+  afterEach(async () => {
+    await groupDbA.destroy()
+    await groupDbB.destroy()
+    await globalDb.destroy()
+  })
+
+  function makeMockGroupDbs() {
+    const map: Record<string, Kysely<GroupDatabase>> = {
+      [groupADid]: groupDbA,
+      [groupBDid]: groupDbB,
+    }
+    return { get: (did: string) => map[did] } as any
+  }
+
+  it('backfills all members from all groups', async () => {
+    const count = await backfillMemberIndex(globalDb, makeMockGroupDbs())
+    expect(count).toBe(4)
+
+    const rows = await globalDb.selectFrom('member_index').selectAll().execute()
+    expect(rows).toHaveLength(4)
+
+    // Verify alice appears in both groups
+    const aliceRows = rows.filter((r) => r.member_did === 'did:plc:alice')
+    expect(aliceRows).toHaveLength(2)
+    const aliceGroups = aliceRows.map((r) => r.group_did).sort()
+    expect(aliceGroups).toEqual([groupADid, groupBDid])
+
+    // Verify roles are correct
+    const aliceA = aliceRows.find((r) => r.group_did === groupADid)
+    expect(aliceA!.role).toBe('owner')
+    const aliceB = aliceRows.find((r) => r.group_did === groupBDid)
+    expect(aliceB!.role).toBe('member')
+
+    // Verify added_at is populated
+    for (const row of rows) {
+      expect(row.added_at).toBeDefined()
+    }
+  })
+
+  it('idempotent — running twice does not duplicate', async () => {
+    await backfillMemberIndex(globalDb, makeMockGroupDbs())
+    await backfillMemberIndex(globalDb, makeMockGroupDbs())
+
+    const rows = await globalDb.selectFrom('member_index').selectAll().execute()
+    expect(rows).toHaveLength(4)
+  })
+
+  it('skips already-indexed members', async () => {
+    // Pre-index alice in groupA
+    await seedMemberWithIndex(groupDbA, globalDb, 'did:plc:preindexed', groupADid, 'member')
+
+    // Remove from group_members to avoid double-insert during backfill
+    // (seedMemberWithIndex already inserted into group_members)
+    // Actually, backfill reads group_members and inserts with onConflict doNothing,
+    // so pre-indexed alice via seedMemberWithIndex should not cause duplicates.
+
+    // Backfill should not duplicate the pre-indexed row
+    await backfillMemberIndex(globalDb, makeMockGroupDbs())
+
+    const rows = await globalDb.selectFrom('member_index').selectAll().execute()
+    // 4 from backfill + 1 pre-indexed = 5 unique rows
+    expect(rows).toHaveLength(5)
+
+    // Verify no duplicates per (member_did, group_did)
+    const keys = rows.map((r) => `${r.member_did}::${r.group_did}`)
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+})

--- a/tests/membership.test.ts
+++ b/tests/membership.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import express from 'express'
 import request from 'supertest'
-import { createTestContext, seedMember, createTestApp, mockAuth } from './helpers/mock-server.js'
+import { createTestContext, seedMember, seedMemberWithIndex, createTestApp, mockAuth } from './helpers/mock-server.js'
 import memberAddHandler from '../src/api/member/add.js'
 import memberRemoveHandler from '../src/api/member/remove.js'
 import memberListHandler from '../src/api/member/list.js'
@@ -9,7 +9,7 @@ import roleSetHandler from '../src/api/role/set.js'
 import auditQueryHandler from '../src/api/audit/query.js'
 import type { AppContext } from '../src/context.js'
 import type { Kysely } from 'kysely'
-import type { GroupDatabase } from '../src/db/schema.js'
+import type { GlobalDatabase, GroupDatabase } from '../src/db/schema.js'
 
 function buildApp(ctx: AppContext) {
   return createTestApp(ctx, (server, appCtx) => {
@@ -23,12 +23,14 @@ function buildApp(ctx: AppContext) {
 
 describe('member.add', () => {
   let ctx: AppContext
+  let globalDb: Kysely<GlobalDatabase>
   let groupDb: Kysely<GroupDatabase>
   let app: express.Express
 
   beforeEach(async () => {
     const test = await createTestContext()
     ctx = test.ctx
+    globalDb = test.globalDb
     groupDb = test.groupDb
     await seedMember(groupDb, 'did:plc:testuser', 'admin')
     app = buildApp(ctx)
@@ -47,6 +49,16 @@ describe('member.add', () => {
     expect(res.body.role).toBe('member')
     expect(res.body.addedBy).toBe('did:plc:testuser')
     expect(res.body.addedAt).toBeDefined()
+
+    // Verify member_index is in sync
+    const indexRow = await globalDb
+      .selectFrom('member_index')
+      .selectAll()
+      .where('member_did', '=', 'did:plc:newuser')
+      .executeTakeFirst()
+    expect(indexRow).toBeDefined()
+    expect(indexRow!.role).toBe('member')
+    expect(indexRow!.group_did).toBe('did:plc:testgroup')
   })
 
   it('admin cannot add another admin (role >= own)', async () => {
@@ -131,12 +143,14 @@ describe('member.add', () => {
 
 describe('member.remove', () => {
   let ctx: AppContext
+  let globalDb: Kysely<GlobalDatabase>
   let groupDb: Kysely<GroupDatabase>
   let app: express.Express
 
   beforeEach(async () => {
     const test = await createTestContext()
     ctx = test.ctx
+    globalDb = test.globalDb
     groupDb = test.groupDb
     await seedMember(groupDb, 'did:plc:testuser', 'admin')
     app = buildApp(ctx)
@@ -154,6 +168,14 @@ describe('member.remove', () => {
     expect(res.status).toBe(200)
     const remaining = await groupDb.selectFrom('group_members').selectAll().where('member_did', '=', 'did:plc:target').execute()
     expect(remaining).toHaveLength(0)
+
+    // Verify member_index row is also removed
+    const indexRow = await globalDb
+      .selectFrom('member_index')
+      .selectAll()
+      .where('member_did', '=', 'did:plc:target')
+      .executeTakeFirst()
+    expect(indexRow).toBeUndefined()
   })
 
   it('cannot remove owner', async () => {
@@ -286,12 +308,14 @@ describe('member.list', () => {
 
 describe('role.set', () => {
   let ctx: AppContext
+  let globalDb: Kysely<GlobalDatabase>
   let groupDb: Kysely<GroupDatabase>
   let app: express.Express
 
   beforeEach(async () => {
     const test = await createTestContext()
     ctx = test.ctx
+    globalDb = test.globalDb
     groupDb = test.groupDb
     await seedMember(groupDb, 'did:plc:testuser', 'owner')
     app = buildApp(ctx)
@@ -302,12 +326,21 @@ describe('role.set', () => {
   })
 
   it('owner promotes member to admin', async () => {
-    await seedMember(groupDb, 'did:plc:target', 'member')
+    await seedMemberWithIndex(groupDb, globalDb, 'did:plc:target', 'did:plc:testgroup', 'member')
     const res = await request(app)
       .post('/xrpc/app.certified.group.role.set')
       .send({ memberDid: 'did:plc:target', role: 'admin' })
     expect(res.status).toBe(200)
     expect(res.body.role).toBe('admin')
+
+    // Verify member_index role is updated
+    const indexRow = await globalDb
+      .selectFrom('member_index')
+      .selectAll()
+      .where('member_did', '=', 'did:plc:target')
+      .executeTakeFirst()
+    expect(indexRow).toBeDefined()
+    expect(indexRow!.role).toBe('admin')
   })
 
   it('rejects changing owner role with CannotModifyOwner', async () => {

--- a/tests/membership.test.ts
+++ b/tests/membership.test.ts
@@ -310,20 +310,21 @@ describe('role.set', () => {
     expect(res.body.role).toBe('admin')
   })
 
-  it('prevents last owner demotion', async () => {
+  it('rejects changing owner role with CannotModifyOwner', async () => {
     const res = await request(app)
       .post('/xrpc/app.certified.group.role.set')
       .send({ memberDid: 'did:plc:testuser', role: 'admin' })
     expect(res.status).toBe(400)
-    expect(res.body.error).toBe('LastOwnerDemotion')
+    expect(res.body.error).toBe('CannotModifyOwner')
   })
 
-  it('allows owner demotion when another owner exists', async () => {
-    await seedMember(groupDb, 'did:plc:owner2', 'owner')
+  it('rejects promoting to owner with CannotPromoteToOwner', async () => {
+    await seedMember(groupDb, 'did:plc:admin1', 'admin')
     const res = await request(app)
       .post('/xrpc/app.certified.group.role.set')
-      .send({ memberDid: 'did:plc:testuser', role: 'admin' })
-    expect(res.status).toBe(200)
+      .send({ memberDid: 'did:plc:admin1', role: 'owner' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('CannotPromoteToOwner')
   })
 
   it('non-owner cannot set roles', async () => {

--- a/tests/putRecord.test.ts
+++ b/tests/putRecord.test.ts
@@ -20,12 +20,13 @@ describe('putRecord — cross-member update', () => {
   let app: Express
 
   beforeEach(async () => {
-    groupDb = await createTestGroupDb()
+    const testGroup = await createTestGroupDb()
+    groupDb = testGroup.db
     await seedMember(groupDb, CALLER_DID, 'member')
     // Seed a record authored by a different user
     await seedAuthorship(groupDb, RECORD_URI, OTHER_AUTHOR, COLLECTION)
     const { ctx } = await createTestContext({
-      groupDbs: { get: () => groupDb, migrateGroup: async () => {}, destroyAll: async () => {} } as any,
+      groupDbs: { get: () => groupDb, getRaw: () => testGroup.raw, migrateGroup: async () => {}, destroyAll: async () => {} } as any,
     })
     app = createTestApp(ctx, (server, appCtx) => {
       putRecordHandler(server, appCtx)

--- a/tests/rbac.test.ts
+++ b/tests/rbac.test.ts
@@ -37,7 +37,8 @@ describe('RbacChecker', () => {
   let rbac: RbacChecker
 
   beforeEach(async () => {
-    groupDb = await createTestGroupDb()
+    const testGroup = await createTestGroupDb()
+    groupDb = testGroup.db
     rbac = new RbacChecker()
     await seedMember(groupDb, 'did:plc:member1', 'member')
   })

--- a/tests/role.set.test.ts
+++ b/tests/role.set.test.ts
@@ -1,18 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import express from 'express'
 import request from 'supertest'
-import { XRPCError } from '@atproto/xrpc-server'
 import type { Kysely } from 'kysely'
 import type { GroupDatabase } from '../src/db/schema.js'
 import { createTestGroupDb } from './helpers/test-db.js'
-import { createTestContext, seedMember, createTestApp } from './helpers/mock-server.js'
+import { createTestContext, seedMember, createTestApp, mockAuth } from './helpers/mock-server.js'
 import roleSetHandler from '../src/api/role/set.js'
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('role.set — last-owner protection', () => {
+describe('role.set', () => {
   let groupDb: Kysely<GroupDatabase>
   let app: express.Express
 
@@ -32,28 +31,7 @@ describe('role.set — last-owner protection', () => {
     await groupDb.destroy()
   })
 
-  it('successfully demotes an owner when another owner remains', async () => {
-    await seedMember(groupDb, 'did:plc:victim', 'owner')
-
-    const res = await request(app)
-      .post('/xrpc/app.certified.group.role.set')
-      .send({ memberDid: 'did:plc:victim', role: 'member' })
-
-    expect(res.status).toBe(200)
-    expect(res.body).toMatchObject({ memberDid: 'did:plc:victim', role: 'member' })
-  })
-
-  it('rejects demotion of the sole owner with LastOwnerDemotion', async () => {
-    // testuser is the only owner
-    const res = await request(app)
-      .post('/xrpc/app.certified.group.role.set')
-      .send({ memberDid: 'did:plc:testuser', role: 'member' })
-
-    expect(res.status).toBe(400)
-    expect(res.body.error).toBe('LastOwnerDemotion')
-  })
-
-  it('promotes a non-owner member without the last-owner check', async () => {
+  it('promotes member to admin', async () => {
     await seedMember(groupDb, 'did:plc:member1', 'member')
 
     const res = await request(app)
@@ -63,6 +41,54 @@ describe('role.set — last-owner protection', () => {
     expect(res.status).toBe(200)
     expect(res.body).toMatchObject({ memberDid: 'did:plc:member1', role: 'admin' })
   })
+
+  it('demotes admin to member', async () => {
+    await seedMember(groupDb, 'did:plc:admin1', 'admin')
+
+    const res = await request(app)
+      .post('/xrpc/app.certified.group.role.set')
+      .send({ memberDid: 'did:plc:admin1', role: 'member' })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ memberDid: 'did:plc:admin1', role: 'member' })
+  })
+
+  it('setting same role is a no-op success', async () => {
+    await seedMember(groupDb, 'did:plc:admin1', 'admin')
+    const res = await request(app)
+      .post('/xrpc/app.certified.group.role.set')
+      .send({ memberDid: 'did:plc:admin1', role: 'admin' })
+    expect(res.status).toBe(200)
+    expect(res.body.role).toBe('admin')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Owner role is immutable via role.set
+  // ---------------------------------------------------------------------------
+
+  it('rejects changing owner role with CannotModifyOwner', async () => {
+    const res = await request(app)
+      .post('/xrpc/app.certified.group.role.set')
+      .send({ memberDid: 'did:plc:testuser', role: 'admin' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('CannotModifyOwner')
+  })
+
+  it('rejects promoting to owner with CannotPromoteToOwner', async () => {
+    await seedMember(groupDb, 'did:plc:admin1', 'admin')
+
+    const res = await request(app)
+      .post('/xrpc/app.certified.group.role.set')
+      .send({ memberDid: 'did:plc:admin1', role: 'owner' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('CannotPromoteToOwner')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Standard guards
+  // ---------------------------------------------------------------------------
 
   it('rejects role change for unknown member with MemberNotFound', async () => {
     const res = await request(app)
@@ -82,28 +108,6 @@ describe('role.set — last-owner protection', () => {
     expect(res.body.error).toBe('InvalidRole')
   })
 
-  it('owner can promote member to owner', async () => {
-    await seedMember(groupDb, 'did:plc:member1', 'member')
-    const res = await request(app)
-      .post('/xrpc/app.certified.group.role.set')
-      .send({ memberDid: 'did:plc:member1', role: 'owner' })
-    expect(res.status).toBe(200)
-    expect(res.body.role).toBe('owner')
-
-    const member = await groupDb.selectFrom('group_members')
-      .select('role').where('member_did', '=', 'did:plc:member1').executeTakeFirst()
-    expect(member!.role).toBe('owner')
-  })
-
-  it('setting same role is a no-op success', async () => {
-    await seedMember(groupDb, 'did:plc:admin1', 'admin')
-    const res = await request(app)
-      .post('/xrpc/app.certified.group.role.set')
-      .send({ memberDid: 'did:plc:admin1', role: 'admin' })
-    expect(res.status).toBe(200)
-    expect(res.body.role).toBe('admin')
-  })
-
   it('audit log records previousRole and newRole', async () => {
     await seedMember(groupDb, 'did:plc:target', 'member')
     await request(app)
@@ -116,133 +120,5 @@ describe('role.set — last-owner protection', () => {
     expect(detail.previousRole).toBe('member')
     expect(detail.newRole).toBe('admin')
     expect(detail.memberDid).toBe('did:plc:target')
-  })
-
-  // ---------------------------------------------------------------------------
-  // Happy-path concurrency: with 3 owners, both concurrent demotions are valid
-  // and should both succeed, leaving exactly 1 owner.
-  // ---------------------------------------------------------------------------
-  it('concurrent demotions of two owners both succeed when a third owner remains', async () => {
-    await seedMember(groupDb, 'did:plc:victim1', 'owner')
-    await seedMember(groupDb, 'did:plc:victim2', 'owner')
-    // Now there are 3 owners: testuser, victim1, victim2.
-    // Demoting victim1 and victim2 concurrently would leave testuser as sole owner.
-    // Because there are 3 owners, both demotions are individually valid, so both
-    // should succeed — verifying the happy path is not broken.
-    const [r1, r2] = await Promise.all([
-      request(app)
-        .post('/xrpc/app.certified.group.role.set')
-        .send({ memberDid: 'did:plc:victim1', role: 'member' }),
-      request(app)
-        .post('/xrpc/app.certified.group.role.set')
-        .send({ memberDid: 'did:plc:victim2', role: 'member' }),
-    ])
-    expect(r1.status).toBe(200)
-    expect(r2.status).toBe(200)
-
-    const owners = await groupDb
-      .selectFrom('group_members')
-      .where('role', '=', 'owner')
-      .selectAll()
-      .execute()
-    expect(owners).toHaveLength(1)
-    expect(owners[0].member_did).toBe('did:plc:testuser')
-  })
-
-  it('sequential demotions: demoting the last remaining owner is rejected', async () => {
-    await seedMember(groupDb, 'did:plc:victim', 'owner')
-    // testuser + victim = 2 owners. Demote victim, then try to demote testuser.
-    const r1 = await request(app)
-      .post('/xrpc/app.certified.group.role.set')
-      .send({ memberDid: 'did:plc:victim', role: 'member' })
-    expect(r1.status).toBe(200)
-
-    // Only testuser remains as owner — demoting them must fail
-    const r2 = await request(app)
-      .post('/xrpc/app.certified.group.role.set')
-      .send({ memberDid: 'did:plc:testuser', role: 'member' })
-    expect(r2.status).toBe(400)
-    expect(r2.body.error).toBe('LastOwnerDemotion')
-
-    const owners = await groupDb
-      .selectFrom('group_members')
-      .where('role', '=', 'owner')
-      .selectAll()
-      .execute()
-    expect(owners).toHaveLength(1)
-    expect(owners[0].member_did).toBe('did:plc:testuser')
-  })
-})
-
-// ---------------------------------------------------------------------------
-// Unit-level atomicity test: directly exercises the transaction logic,
-// confirming two concurrent demotions of two SEPARATE owners (2-owner DB)
-// result in exactly 1 success and 1 LastOwnerDemotion failure.
-// ---------------------------------------------------------------------------
-describe('role.set — transaction atomicity (direct DB)', () => {
-  let groupDb: Kysely<GroupDatabase>
-
-  beforeEach(async () => {
-    groupDb = await createTestGroupDb()
-    await seedMember(groupDb, 'did:plc:owner1', 'owner')
-    await seedMember(groupDb, 'did:plc:owner2', 'owner')
-  })
-
-  afterEach(async () => {
-    await groupDb.destroy()
-  })
-
-  /** Replicates the atomic demotion logic from the fixed set.ts handler. */
-  function atomicDemote(memberDid: string, newRole: string): Promise<void> {
-    return groupDb.transaction().execute(async (trx) => {
-      const ownerCount = await trx
-        .selectFrom('group_members')
-        .where('role', '=', 'owner')
-        .select(trx.fn.countAll().as('count'))
-        .executeTakeFirstOrThrow()
-      if (Number(ownerCount.count) <= 1) {
-        throw new XRPCError(400,
-          'Cannot demote the last owner — promote a replacement first', 'LastOwnerDemotion')
-      }
-      await trx
-        .updateTable('group_members')
-        .set({ role: newRole })
-        .where('member_did', '=', memberDid)
-        .execute()
-    })
-  }
-
-  it('two concurrent owner demotions (2 owners total): exactly one succeeds', async () => {
-    const results = await Promise.allSettled([
-      atomicDemote('did:plc:owner1', 'member'),
-      atomicDemote('did:plc:owner2', 'member'),
-    ])
-
-    const fulfilled = results.filter((r) => r.status === 'fulfilled')
-    const rejected = results.filter((r) => r.status === 'rejected') as PromiseRejectedResult[]
-
-    expect(fulfilled).toHaveLength(1)
-    expect(rejected).toHaveLength(1)
-    expect(rejected[0].reason.customErrorName).toBe('LastOwnerDemotion')
-
-    const owners = await groupDb
-      .selectFrom('group_members')
-      .where('role', '=', 'owner')
-      .selectAll()
-      .execute()
-    expect(owners).toHaveLength(1)
-  })
-
-  it('single owner cannot be demoted', async () => {
-    // Remove owner2 first so only owner1 remains
-    await groupDb
-      .updateTable('group_members')
-      .set({ role: 'member' })
-      .where('member_did', '=', 'did:plc:owner2')
-      .execute()
-
-    await expect(atomicDemote('did:plc:owner1', 'member')).rejects.toMatchObject({
-      customErrorName: 'LastOwnerDemotion',
-    })
   })
 })

--- a/tests/role.set.test.ts
+++ b/tests/role.set.test.ts
@@ -16,11 +16,12 @@ describe('role.set', () => {
   let app: express.Express
 
   beforeEach(async () => {
-    groupDb = await createTestGroupDb()
+    const testGroup = await createTestGroupDb()
+    groupDb = testGroup.db
     // createTestContext mock auth always returns callerDid = 'did:plc:testuser'
     await seedMember(groupDb, 'did:plc:testuser', 'owner')
     const { ctx } = await createTestContext({
-      groupDbs: { get: () => groupDb, migrateGroup: async () => {}, destroyAll: async () => {} } as any,
+      groupDbs: { get: () => groupDb, getRaw: () => testGroup.raw, migrateGroup: async () => {}, destroyAll: async () => {} } as any,
     })
     app = createTestApp(ctx, (server, appCtx) => {
       roleSetHandler(server, appCtx)

--- a/tests/verifier.test.ts
+++ b/tests/verifier.test.ts
@@ -24,7 +24,8 @@ describe('AuthVerifier', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
-    globalDb = await createTestGlobalDb()
+    const testGlobal = await createTestGlobalDb()
+    globalDb = testGlobal.db
     await globalDb.insertInto('groups').values({
       did: 'did:plc:testgroup',
       pds_url: 'https://pds.example.com',

--- a/tests/verifier.test.ts
+++ b/tests/verifier.test.ts
@@ -168,3 +168,125 @@ describe('AuthVerifier', () => {
     expect(mockIdResolver.did.resolveAtprotoData).toHaveBeenCalledWith('did:plc:caller', false)
   })
 })
+
+describe('verifyServiceAuth', () => {
+  let globalDb: Kysely<GlobalDatabase>
+  let nonceCache: NonceCache
+  let verifier: AuthVerifier
+
+  const fakeVerifyJwt = vi.fn()
+  const fakeParseReqNsid = vi.fn()
+  const mockIdResolver = {
+    did: {
+      resolveAtprotoData: vi.fn().mockResolvedValue({ signingKey: 'test-signing-key' }),
+    },
+  }
+
+  const SERVICE_DID = 'did:web:test.example.com'
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const testGlobal = await createTestGlobalDb()
+    globalDb = testGlobal.db
+    nonceCache = new NonceCache(globalDb)
+    verifier = new AuthVerifier(
+      mockIdResolver as any,
+      nonceCache,
+      globalDb,
+      SERVICE_DID,
+      fakeVerifyJwt,
+      fakeParseReqNsid,
+    )
+
+    fakeParseReqNsid.mockReturnValue('app.certified.groups.membership.list')
+    const now = Math.floor(Date.now() / 1000)
+    fakeVerifyJwt.mockResolvedValue({
+      iss: 'did:plc:caller',
+      aud: SERVICE_DID,
+      jti: 'jti-unique',
+      iat: now,
+      exp: now + 60,
+    })
+  })
+
+  it('rejects missing Authorization header', async () => {
+    const req = makeReq({}, '/xrpc/app.certified.groups.membership.list')
+    await expect(verifier.verifyServiceAuth(req)).rejects.toThrow('Missing auth token')
+  })
+
+  it('rejects non-Bearer token', async () => {
+    const req = makeReq({ authorization: 'Basic abc' }, '/xrpc/app.certified.groups.membership.list')
+    await expect(verifier.verifyServiceAuth(req)).rejects.toThrow('Missing auth token')
+  })
+
+  it('rejects token lifetime exceeding nonce TTL', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    fakeVerifyJwt.mockResolvedValue({
+      iss: 'did:plc:caller',
+      aud: SERVICE_DID,
+      jti: 'jti-long',
+      iat: now,
+      exp: now + NONCE_TTL_SECONDS + 60,
+    })
+    const req = makeReq({ authorization: 'Bearer jwt' }, '/xrpc/app.certified.groups.membership.list')
+    await expect(verifier.verifyServiceAuth(req)).rejects.toThrow('Token lifetime exceeds nonce window')
+  })
+
+  it('rejects missing iat', async () => {
+    fakeVerifyJwt.mockResolvedValue({
+      iss: 'did:plc:caller',
+      aud: SERVICE_DID,
+      jti: 'jti-no-iat',
+      exp: Math.floor(Date.now() / 1000) + 60,
+    })
+    const req = makeReq({ authorization: 'Bearer jwt' }, '/xrpc/app.certified.groups.membership.list')
+    await expect(verifier.verifyServiceAuth(req)).rejects.toThrow('Missing iat in service auth token')
+  })
+
+  it('rejects missing jti', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    fakeVerifyJwt.mockResolvedValue({
+      iss: 'did:plc:caller',
+      aud: SERVICE_DID,
+      jti: undefined,
+      iat: now,
+      exp: now + 60,
+    })
+    const req = makeReq({ authorization: 'Bearer jwt' }, '/xrpc/app.certified.groups.membership.list')
+    await expect(verifier.verifyServiceAuth(req)).rejects.toThrow('Missing jti in service auth token')
+  })
+
+  it('rejects replayed token (duplicate jti)', async () => {
+    await nonceCache.checkAndStore('jti-replayed')
+    const now = Math.floor(Date.now() / 1000)
+    fakeVerifyJwt.mockResolvedValue({
+      iss: 'did:plc:caller',
+      aud: SERVICE_DID,
+      jti: 'jti-replayed',
+      iat: now,
+      exp: now + 60,
+    })
+    const req = makeReq({ authorization: 'Bearer jwt' }, '/xrpc/app.certified.groups.membership.list')
+    await expect(verifier.verifyServiceAuth(req)).rejects.toThrow('Replayed token')
+  })
+
+  it('valid token returns only iss (no aud)', async () => {
+    const req = makeReq({ authorization: 'Bearer jwt' }, '/xrpc/app.certified.groups.membership.list')
+    const result = await verifier.verifyServiceAuth(req)
+    expect(result).toEqual({ iss: 'did:plc:caller' })
+  })
+
+  it('passes serviceDid as audience to verifyJwt', async () => {
+    const req = makeReq({ authorization: 'Bearer jwt' }, '/xrpc/app.certified.groups.membership.list')
+    await verifier.verifyServiceAuth(req)
+    expect(fakeVerifyJwt).toHaveBeenCalled()
+    expect(fakeVerifyJwt.mock.calls[0][1]).toBe(SERVICE_DID)
+  })
+
+  it('passes parsed NSID to verifyJwt', async () => {
+    fakeParseReqNsid.mockReturnValue('app.certified.groups.membership.list')
+    const req = makeReq({ authorization: 'Bearer jwt' }, '/xrpc/app.certified.groups.membership.list')
+    await verifier.verifyServiceAuth(req)
+    expect(fakeVerifyJwt.mock.calls[0][2]).toBe('app.certified.groups.membership.list')
+  })
+})


### PR DESCRIPTION
## Summary
- **`app.certified.groups.membership.list` endpoint** — authenticated users can query which groups they belong to across the entire service, with role and join date
- **`member_index` table** — global index that tracks memberships across all per-group databases, kept in sync by mutation handlers (`member.add`, `member.remove`, `role.set`) and backfillable for existing data
- **Service-level auth** (`verifyServiceAuth` / `xrpcServiceAuth`) — supports cross-group endpoints where audience is the service DID, not a group DID
- **Single-owner invariant** — `role.set` now rejects modifying the owner role or promoting to owner with explicit errors

## Implementation Details
- `member_index` uses `ATTACH DATABASE` in production for atomic cross-DB writes (group DB + global DB in one transaction); tests use `TestMemberIndex` with sequential writes for in-memory DBs
- Cursor-based pagination with `added_at::group_did` composite cursor for stable ordering, including tie-breaking when timestamps collide
- Raw SQLite connections exposed alongside Kysely instances to support the ATTACH pattern
- Lexicon defined at `lexicons/app/certified/groups/membership/list.json`

## Test plan
- [x] `verifyServiceAuth()` unit tests (missing header, non-Bearer, lifetime, iat, jti, replay, valid token, audience, NSID)
- [x] Cursor tie-breaking with identical `added_at` timestamps
- [x] Multi-page pagination (7 memberships across 3 pages)
- [x] `member_index` sync assertions on `member.add`, `member.remove`, `role.set`
- [x] Production `MemberIndex` ATTACH DATABASE atomicity (add, remove, updateRole, rollback on PK violation, DETACH cleanup)
- [x] `member_index` round-trip and backfill tests
- [x] Membership listing happy paths (empty, filtering, roles, pagination, validation)
- [x] Role.set owner invariant guards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added membership listing endpoint with pagination and service-level auth for cross-group queries.

* **Bug Fixes**
  * Owner role changes are disallowed; promoting to owner is rejected with explicit errors.

* **Documentation**
  * Clarified JWT audience guidance and updated test-running instructions.

* **Tests**
  * Expanded tests for membership listing, member-index, backfill, and revised role-change expectations.

* **Chores**
  * Introduced a global member index, migration, and idempotent backfill; integrated index into startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->