### PR TITLE
fix(demo): require SESSION_SECRET at startup, no default

### DIFF
--- a/demo/.env.example
+++ b/demo/.env.example
@@ -2,7 +2,8 @@
 GROUP_SERVICE_URL=https://atproto-group-gate-staging.up.railway.app
 GROUP_SERVICE_DID=did:web:atproto-group-gate-staging.up.railway.app
 EPDS_URL=https://epds1.test.certified.app
-SESSION_SECRET=change-me-to-a-random-string
+# required: generate with e.g. openssl rand -hex 32
+SESSION_SECRET=""
 
 # OAuth client metadata URL (must be publicly accessible so ePDS can fetch it)
 OAUTH_CLIENT_ID=https://your-demo-domain.com/client-metadata.json

--- a/demo/server/index.ts
+++ b/demo/server/index.ts
@@ -10,12 +10,15 @@ import registerRoutes from './routes/register.js'
 const app = express()
 const PORT = parseInt(process.env.BFF_PORT || '3001', 10)
 
+const sessionSecret = process.env.SESSION_SECRET
+if (!sessionSecret) throw new Error('SESSION_SECRET must be set')
+
 app.use(cors({ origin: true, credentials: true }))
 app.use(express.json())
 
 app.use(
   session({
-    secret: process.env.SESSION_SECRET || 'dev-secret',
+    secret: sessionSecret,
     resave: false,
     saveUninitialized: false,
     cookie: {

--- a/demo/server/index.ts
+++ b/demo/server/index.ts
@@ -14,6 +14,10 @@ const sessionSecret = process.env.SESSION_SECRET
 if (!sessionSecret) throw new Error('SESSION_SECRET must be set')
 
 app.use(cors({ origin: true, credentials: true }))
+
+// Mount upload route before express.json() to preserve raw stream access
+app.use('/api/upload-blob', uploadRoutes)
+
 app.use(express.json())
 
 app.use(
@@ -52,7 +56,6 @@ app.get('/client-metadata.json', (_req, res) => {
 // Routes
 app.use('/api', authRoutes)
 app.use('/api/proxy', proxyRoutes)
-app.use('/api/upload-blob', uploadRoutes)
 app.use('/api/register', registerRoutes)
 
 // Health check


### PR DESCRIPTION
Closes #4

## Summary

- Removes the `|| 'dev-secret'` fallback from `demo/server/index.ts`
- Throws `Error('SESSION_SECRET must be set')` at startup if the env var is absent or empty — the process will not start without it
- Updates `demo/.env.example` to make clear the value is required and how to generate one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated environment example to require a session secret and added instructions for generating a secure value.

* **Bug Fixes**
  * Application now validates the session secret at startup to prevent running with a default/empty value.
  * Upload handling order adjusted so raw upload requests are preserved and processed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->