### PR TITLE
ci: build multi-arch Docker images (amd64 + arm64)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -36,6 +38,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Add `docker/setup-qemu-action@v3` for cross-platform emulation
- Add `linux/arm64` platform to `docker/build-push-action` so published images work natively on Apple Silicon Macs
- Existing `linux/amd64` support unchanged; Docker serves correct arch via manifest list

## Test plan
- [ ] Verify CI workflow runs successfully and publishes multi-arch manifest
- [ ] Pull image on Apple Silicon Mac and confirm it runs without Rosetta emulation (`docker inspect` shows `arm64`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)