### PR TITLE
feat(auth): log JWT header+payload on auth verification failures

### DIFF
--- a/src/auth/verifier.ts
+++ b/src/auth/verifier.ts
@@ -7,8 +7,26 @@ import {
 } from '@atproto/xrpc-server'
 import type { Kysely } from 'kysely'
 import type { Request } from 'express'
+import type { Logger } from 'pino'
 import type { GlobalDatabase } from '../db/schema.js'
 import { NonceCache, NONCE_TTL_SECONDS } from './nonce.js'
+
+/**
+ * Decode the header+payload of a JWT without verifying its signature, for
+ * logging purposes only. Returns null on malformed input. The signature is
+ * deliberately dropped — it's a bearer credential and must not be logged.
+ */
+function decodeJwtForLog(jwt: string): { header: unknown; payload: unknown } | null {
+  const parts = jwt.split('.')
+  if (parts.length < 2) return null
+  try {
+    const decode = (s: string): unknown =>
+      JSON.parse(Buffer.from(s.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'))
+    return { header: decode(parts[0]), payload: decode(parts[1]) }
+  } catch {
+    return null
+  }
+}
 
 export interface GroupAuthCredentials {
   callerDid: string
@@ -26,6 +44,7 @@ const REGISTER_NSID = 'app.certified.group.register'
 export class AuthVerifier {
   private verifyJwtFn: typeof defaultVerifyJwt
   private parseReqNsidFn: typeof defaultParseReqNsid
+  private logger?: Logger
 
   constructor(
     private idResolver: IdResolver,
@@ -34,9 +53,29 @@ export class AuthVerifier {
     private serviceDid: string,
     verifyJwtFn?: typeof defaultVerifyJwt,
     parseReqNsidFn?: typeof defaultParseReqNsid,
+    logger?: Logger,
   ) {
     this.verifyJwtFn = verifyJwtFn ?? defaultVerifyJwt
     this.parseReqNsidFn = parseReqNsidFn ?? defaultParseReqNsid
+    this.logger = logger
+  }
+
+  /**
+   * Log an auth failure with enough context to diagnose prod 401s without
+   * leaking the JWT signature. Header+payload only; raw token is never logged.
+   */
+  private logAuthFailure(
+    reason: string,
+    nsid: string | undefined,
+    jwt: string,
+    extra: Record<string, unknown> = {},
+  ): void {
+    if (!this.logger) return
+    const decoded = decodeJwtForLog(jwt)
+    this.logger.warn(
+      { reason, nsid, jwt: decoded, ...extra },
+      'Auth verification failed',
+    )
   }
 
   private assertTokenLifetime(payload: { iat?: number; exp?: number }): void {
@@ -51,6 +90,10 @@ export class AuthVerifier {
   async verify(req: Request): Promise<{ iss: string; aud: string }> {
     const authHeader = req.headers.authorization
     if (!authHeader?.startsWith('Bearer ')) {
+      this.logger?.warn(
+        { reason: 'Missing auth token', path: req.originalUrl ?? req.path },
+        'Auth verification failed',
+      )
       throw new AuthRequiredError('Missing auth token')
     }
     const jwtStr = authHeader.slice(7)
@@ -58,17 +101,32 @@ export class AuthVerifier {
 
     // verifyJwt checks: aud, lxm, exp, signature against DID doc.
     // Pass null for aud — we check it ourselves because we support multiple groups.
-    const payload = await this.verifyJwtFn(
-      jwtStr,
-      null,
-      nsid,
-      async (did: string, forceRefresh: boolean): Promise<string> => {
-        const atprotoData = await this.idResolver.did.resolveAtprotoData(did, forceRefresh)
-        return atprotoData.signingKey
-      },
-    )
+    let payload
+    try {
+      payload = await this.verifyJwtFn(
+        jwtStr,
+        null,
+        nsid,
+        async (did: string, forceRefresh: boolean): Promise<string> => {
+          const atprotoData = await this.idResolver.did.resolveAtprotoData(did, forceRefresh)
+          return atprotoData.signingKey
+        },
+      )
+    } catch (err) {
+      this.logAuthFailure('verifyJwt threw', nsid, jwtStr, {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      throw err
+    }
 
-    this.assertTokenLifetime(payload)
+    try {
+      this.assertTokenLifetime(payload)
+    } catch (err) {
+      this.logAuthFailure('Token lifetime check failed', nsid, jwtStr, {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      throw err
+    }
 
     const group = payload.aud
       ? await this.globalDb
@@ -78,14 +136,19 @@ export class AuthVerifier {
           .executeTakeFirst()
       : undefined
     if (!group) {
+      this.logAuthFailure('Invalid audience', nsid, jwtStr, {
+        groupFound: false,
+      })
       throw new AuthRequiredError('Invalid audience')
     }
 
     if (!payload.jti) {
+      this.logAuthFailure('Missing jti', nsid, jwtStr)
       throw new AuthRequiredError('Missing jti in service auth token')
     }
     const isNew = await this.nonceCache.checkAndStore(payload.jti)
     if (!isNew) {
+      this.logAuthFailure('Replayed token', nsid, jwtStr)
       throw new AuthRequiredError('Replayed token')
     }
 
@@ -100,27 +163,48 @@ export class AuthVerifier {
   async verifyRegistration(req: Request): Promise<{ iss: string }> {
     const authHeader = req.headers.authorization
     if (!authHeader?.startsWith('Bearer ')) {
+      this.logger?.warn(
+        { reason: 'Missing auth token', nsid: REGISTER_NSID, path: req.originalUrl ?? req.path },
+        'Auth verification failed',
+      )
       throw new AuthRequiredError('Missing auth token')
     }
     const jwtStr = authHeader.slice(7)
 
-    const payload = await this.verifyJwtFn(
-      jwtStr,
-      this.serviceDid,
-      REGISTER_NSID,
-      async (did: string, forceRefresh: boolean): Promise<string> => {
-        const atprotoData = await this.idResolver.did.resolveAtprotoData(did, forceRefresh)
-        return atprotoData.signingKey
-      },
-    )
+    let payload
+    try {
+      payload = await this.verifyJwtFn(
+        jwtStr,
+        this.serviceDid,
+        REGISTER_NSID,
+        async (did: string, forceRefresh: boolean): Promise<string> => {
+          const atprotoData = await this.idResolver.did.resolveAtprotoData(did, forceRefresh)
+          return atprotoData.signingKey
+        },
+      )
+    } catch (err) {
+      this.logAuthFailure('verifyJwt threw', REGISTER_NSID, jwtStr, {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      throw err
+    }
 
-    this.assertTokenLifetime(payload)
+    try {
+      this.assertTokenLifetime(payload)
+    } catch (err) {
+      this.logAuthFailure('Token lifetime check failed', REGISTER_NSID, jwtStr, {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      throw err
+    }
 
     if (!payload.jti) {
+      this.logAuthFailure('Missing jti', REGISTER_NSID, jwtStr)
       throw new AuthRequiredError('Missing jti in service auth token')
     }
     const isNew = await this.nonceCache.checkAndStore(payload.jti)
     if (!isNew) {
+      this.logAuthFailure('Replayed token', REGISTER_NSID, jwtStr)
       throw new AuthRequiredError('Replayed token')
     }
 
@@ -143,28 +227,49 @@ export class AuthVerifier {
   async verifyServiceAuth(req: Request): Promise<{ iss: string }> {
     const authHeader = req.headers.authorization
     if (!authHeader?.startsWith('Bearer ')) {
+      this.logger?.warn(
+        { reason: 'Missing auth token', path: req.originalUrl ?? req.path },
+        'Auth verification failed',
+      )
       throw new AuthRequiredError('Missing auth token')
     }
     const jwtStr = authHeader.slice(7)
     const nsid = this.parseReqNsidFn(req)
 
-    const payload = await this.verifyJwtFn(
-      jwtStr,
-      this.serviceDid,
-      nsid,
-      async (did: string, forceRefresh: boolean): Promise<string> => {
-        const atprotoData = await this.idResolver.did.resolveAtprotoData(did, forceRefresh)
-        return atprotoData.signingKey
-      },
-    )
+    let payload
+    try {
+      payload = await this.verifyJwtFn(
+        jwtStr,
+        this.serviceDid,
+        nsid,
+        async (did: string, forceRefresh: boolean): Promise<string> => {
+          const atprotoData = await this.idResolver.did.resolveAtprotoData(did, forceRefresh)
+          return atprotoData.signingKey
+        },
+      )
+    } catch (err) {
+      this.logAuthFailure('verifyJwt threw', nsid, jwtStr, {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      throw err
+    }
 
-    this.assertTokenLifetime(payload)
+    try {
+      this.assertTokenLifetime(payload)
+    } catch (err) {
+      this.logAuthFailure('Token lifetime check failed', nsid, jwtStr, {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      throw err
+    }
 
     if (!payload.jti) {
+      this.logAuthFailure('Missing jti', nsid, jwtStr)
       throw new AuthRequiredError('Missing jti in service auth token')
     }
     const isNew = await this.nonceCache.checkAndStore(payload.jti)
     if (!isNew) {
+      this.logAuthFailure('Replayed token', nsid, jwtStr)
       throw new AuthRequiredError('Replayed token')
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,15 @@ async function main() {
     () => nonceCache.cleanup().catch((err) => logger.error(err)),
     60_000,
   )
-  const authVerifier = new AuthVerifier(idResolver, nonceCache, globalDb, config.serviceDid)
+  const authVerifier = new AuthVerifier(
+    idResolver,
+    nonceCache,
+    globalDb,
+    config.serviceDid,
+    undefined,
+    undefined,
+    logger,
+  )
   const rbac = new RbacChecker()
 
   // Express app

--- a/tests/verifier.test.ts
+++ b/tests/verifier.test.ts
@@ -358,3 +358,95 @@ describe('verifyServiceAuth', () => {
     expect(fakeVerifyJwt.mock.calls[0][2]).toBe('app.certified.groups.membership.list')
   })
 })
+
+describe('AuthVerifier auth-failure logging', () => {
+  let globalDb: Kysely<GlobalDatabase>
+  let nonceCache: NonceCache
+  let verifier: AuthVerifier
+  let logger: { warn: ReturnType<typeof vi.fn> }
+
+  const fakeVerifyJwt = vi.fn()
+  const fakeParseReqNsid = vi.fn()
+  const mockIdResolver = {
+    did: {
+      resolveAtprotoData: vi.fn().mockResolvedValue({ signingKey: 'test-signing-key' }),
+    },
+  }
+
+  // Encode a fake JWT (header+payload only — signature is irrelevant for the
+  // log decoder, which never verifies it).
+  function encodeJwt(header: object, payload: object): string {
+    const b64 = (o: object) =>
+      Buffer.from(JSON.stringify(o)).toString('base64url')
+    return `${b64(header)}.${b64(payload)}.sig`
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const testGlobal = await createTestGlobalDb()
+    globalDb = testGlobal.db
+    await globalDb.insertInto('groups').values({
+      did: 'did:plc:testgroup',
+      pds_url: 'https://pds.example.com',
+      encrypted_app_password: 'encrypted',
+    }).execute()
+    nonceCache = new NonceCache(globalDb)
+    logger = { warn: vi.fn() }
+    verifier = new AuthVerifier(
+      mockIdResolver as any,
+      nonceCache,
+      globalDb,
+      'did:web:test.example.com',
+      fakeVerifyJwt,
+      fakeParseReqNsid,
+      logger as any,
+    )
+    fakeParseReqNsid.mockReturnValue('com.atproto.repo.putRecord')
+  })
+
+  it('logs decoded JWT header+payload on Invalid audience without leaking signature', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const jwtPayload = { iss: 'did:plc:caller', aud: 'did:plc:wronggroup', jti: 'jti-x', iat: now, exp: now + 60 }
+    const jwtHeader = { alg: 'ES256K', typ: 'JWT' }
+    const jwt = encodeJwt(jwtHeader, jwtPayload)
+    fakeVerifyJwt.mockResolvedValue(jwtPayload)
+
+    await expect(verifier.verify(makeReq({ authorization: `Bearer ${jwt}` }))).rejects.toThrow('Invalid audience')
+
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    const [logCtx, logMsg] = logger.warn.mock.calls[0]
+    expect(logMsg).toBe('Auth verification failed')
+    expect(logCtx.reason).toBe('Invalid audience')
+    expect(logCtx.nsid).toBe('com.atproto.repo.putRecord')
+    expect(logCtx.jwt).toEqual({ header: jwtHeader, payload: jwtPayload })
+    // Signature is the third dot-segment; the logged jwt object must not
+    // contain it under any key.
+    expect(JSON.stringify(logCtx.jwt)).not.toContain('sig')
+  })
+
+  it('logs reason for missing Authorization header without a JWT field', async () => {
+    await expect(verifier.verify(makeReq({}))).rejects.toThrow('Missing auth token')
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    const [logCtx] = logger.warn.mock.calls[0]
+    expect(logCtx.reason).toBe('Missing auth token')
+    expect(logCtx.jwt).toBeUndefined()
+  })
+
+  it('does not log on successful auth', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    fakeVerifyJwt.mockResolvedValue({ iss: 'did:plc:caller', aud: 'did:plc:testgroup', jti: 'jti-ok', iat: now, exp: now + 60 })
+    await verifier.verify(makeReq({ authorization: 'Bearer jwt' }))
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('logs when verifyJwt itself throws (bad signature/lxm/exp)', async () => {
+    fakeVerifyJwt.mockRejectedValue(new Error('jwt signature invalid'))
+    const jwt = encodeJwt({ alg: 'ES256K' }, { iss: 'did:plc:caller', aud: 'did:plc:testgroup' })
+    await expect(verifier.verify(makeReq({ authorization: `Bearer ${jwt}` }))).rejects.toThrow('jwt signature invalid')
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    const [logCtx] = logger.warn.mock.calls[0]
+    expect(logCtx.reason).toBe('verifyJwt threw')
+    expect(logCtx.error).toBe('jwt signature invalid')
+    expect(logCtx.jwt).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- Auth failures in `AuthVerifier` now log at `warn` before throwing, so production 401s (e.g. "Invalid audience") can be diagnosed without reproducing.
- Logged fields: `reason`, `nsid`, decoded JWT `{header, payload}`. Signature is dropped — it's a bearer credential and must not be logged.
- `verifyJwt` itself (signature/lxm/exp failures) is also wrapped so its throws are logged.
- Logger threaded into `AuthVerifier` as an optional constructor arg; existing test arity unchanged.

## Why
The fallback error handler returns `XRPCError` payloads to the client without logging anything (`src/api/error-handler.ts`). A real prod incident — `CGS app.certified.group.repo.putRecord failed (401): invalid audience` — left no server-side trace of `payload.aud`, `payload.iss`, or whether the group row existed, making diagnosis impossible without reproducing.

## Test plan
- [x] `pnpm test` — 220 passing (was 216; +4 new tests in `tests/verifier.test.ts` covering: decoded JWT logged on Invalid audience, signature absent from log; missing-Authorization logs without a `jwt` field; success path logs nothing; `verifyJwt` throws are wrapped and logged).
- [x] `pnpm build` — clean.
- [ ] Manual: deploy and trigger a 401 with a wrong-aud token; confirm CGS logs the decoded payload and that the signature segment never appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authentication system now provides enhanced failure logging with structured diagnostic data, including decoded JWT information and specific error context (invalid audience, missing authorization headers, signature verification failures) to improve troubleshooting and debugging capabilities.

* **Tests**
  * Added comprehensive test coverage for authentication failure logging scenarios to validate diagnostic data accuracy and completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->