### PR TITLE
chore: add pnpm-workspace.yaml with native build allowlist

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  better-sqlite3: true
+  esbuild: true


### PR DESCRIPTION
## Summary
- Add `pnpm-workspace.yaml` to allow native builds for `better-sqlite3` and `esbuild` during `pnpm install`

## Test plan
- [ ] Verify `pnpm install` completes without build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)