### PR TITLE
fix(docker): copy pnpm-workspace.yaml into build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 make g++ \
  && rm -rf /var/lib/apt/lists/*
 RUN corepack enable
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm build


### PR DESCRIPTION
## Summary
- Dockerfile was missing `pnpm-workspace.yaml` in the COPY step before `pnpm install`
- Without it, pnpm 11 rejects `better-sqlite3` and `esbuild` build scripts (`ERR_PNPM_IGNORED_BUILDS`)
- Adds the file to the existing COPY line so `allowBuilds` config is present during install

## Test plan
- [ ] Railway test env build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)