### PR TITLE
docs: correct CGS docs to match implementation (HYPER-332)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@
 - **PDS agent auto-retry**: `PdsAgentPool.withAgent()` silently re-authenticates on 401/expired token and retries once. Don't add your own retry around it.
 - **Nonce TTL is 2 minutes**, hardcoded. JWTs with longer expiry can be replayed after the nonce window closes.
 - **Blob uploads** read the raw request stream into memory (not streamed to PDS). Route registration order matters: `registerRawRoutes` (uploadBlob) is mounted before `express.json()`, `registerJsonRoutes` after. New raw-stream routes go in `registerRawRoutes`.
-- **Owner can only be created** via `group.register` (seeds DB) or `role.set` (owner-only). `member.add` caps at admin.
+- **Owner is created only** via `group.register` (seeds DB) and is immutable thereafter: `role.set` rejects both promoting to owner and modifying an existing owner, and `member.remove` rejects removing an owner. `member.add` caps at admin. Ownership transfer is a separate, not-yet-implemented operation.
 - **Record authorship is immutable**: `onConflict(...).doNothing()` preserves original author on putRecord. Used to gate cross-author mutations — only admins can `putAnyRecord` or `deleteAnyRecord`; members can only edit/delete records they authored.
 - **Profile edits** (`app.bsky.actor.profile` + rkey `self`) use a special operation `putRecord:profile` requiring admin, regardless of authorship.
 - **`datetime('now')` is step-stable, not transaction-stable**: each `prepare().run()` maps to a separate `sqlite3_step()`, so two INSERTs in the same transaction can produce different timestamps. When the same timestamp must appear in multiple tables, read it back from the first INSERT and reuse it.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ CGS acts as an authenticated proxy between clients and a group's PDS:
 | ---------- | ----- | -------------------------------------------------------------------------------------------------------------- |
 | **member** | 0     | Create records, edit/delete own records, upload blobs, list members                                            |
 | **admin**  | 1     | All member permissions + edit/delete any member's records, edit group profile, manage members, query audit log |
-| **owner**  | 2     | All admin permissions + set roles (promote/demote members)                                                     |
+| **owner**  | 2     | All admin permissions + set member/admin roles (the owner role itself is immutable)                            |
 
 ### Storage
 
@@ -43,7 +43,7 @@ pnpm install
 
 # Configure environment
 cp .env.example .env
-# Edit .env — at minimum set ENCRYPTION_KEY and SERVICE_URL
+# Edit .env — at minimum set ENCRYPTION_KEY, SERVICE_URL, and GROUP_PDS_URL
 
 # Generate an encryption key
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
@@ -63,16 +63,19 @@ pnpm dev
 
 ## Environment variables
 
-| Variable           | Required | Default                 | Description                                                                                                                                                     |
-| ------------------ | -------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PORT`             | No       | `3000`                  | HTTP server listen port                                                                                                                                         |
-| `SERVICE_URL`      | **Yes**  | —                       | Public URL of this service (e.g. `https://group-service.example.com`). Written into group DID documents for atproto-proxy resolution.                           |
-| `DATA_DIR`         | No       | `./data`                | Directory for SQLite databases                                                                                                                                  |
-| `ENCRYPTION_KEY`   | **Yes**  | —                       | 32-byte hex key for AES-256-GCM encryption of stored PDS credentials. Generate with: `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"` |
-| `PLC_URL`          | No       | `https://plc.directory` | PLC directory URL for DID resolution                                                                                                                            |
-| `DID_CACHE_TTL_MS` | No       | `600000`                | DID document cache TTL in milliseconds (10 min)                                                                                                                 |
-| `MAX_BLOB_SIZE`    | No       | `5242880`               | Maximum blob upload size in bytes (5 MB)                                                                                                                        |
-| `LOG_LEVEL`        | No       | `info`                  | Log level: `trace`, `debug`, `info`, `warn`, `error`, `fatal`                                                                                                   |
+| Variable                | Required | Default                 | Description                                                                                                                                                     |
+| ----------------------- | -------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                  | No       | `3000`                  | HTTP server listen port                                                                                                                                         |
+| `SERVICE_URL`           | **Yes**  | —                       | Public URL of this service (e.g. `https://group-service.example.com`). Written into group DID documents for atproto-proxy resolution.                           |
+| `SERVICE_DID`           | No       | derived                 | `did:web` DID of this service; derived from `SERVICE_URL` if omitted                                                                                            |
+| `DATA_DIR`              | No       | `./data`                | Directory for SQLite databases                                                                                                                                  |
+| `ENCRYPTION_KEY`        | **Yes**  | —                       | 32-byte hex key for AES-256-GCM encryption of stored PDS credentials. Generate with: `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"` |
+| `GROUP_PDS_URL`         | **Yes**  | —                       | URL of the PDS where group accounts are created                                                                                                                 |
+| `GROUP_PDS_INVITE_CODE` | No       | —                       | Invite code for account creation on the group PDS                                                                                                               |
+| `PLC_URL`               | No       | `https://plc.directory` | PLC directory URL for DID resolution                                                                                                                            |
+| `DID_CACHE_TTL_MS`      | No       | `600000`                | DID document cache TTL in milliseconds (10 min)                                                                                                                 |
+| `MAX_BLOB_SIZE`         | No       | `5242880`               | Maximum blob upload size in bytes (5 MB)                                                                                                                        |
+| `LOG_LEVEL`             | No       | `info`                  | Log level: `trace`, `debug`, `info`, `warn`, `error`, `fatal`                                                                                                   |
 
 ## Running tests
 
@@ -91,6 +94,7 @@ docker build -t group-service .
 docker run -p 3000:3000 \
   -e SERVICE_URL=https://group-service.example.com \
   -e ENCRYPTION_KEY=<your-64-char-hex-key> \
+  -e GROUP_PDS_URL=https://pds.example.com \
   -v $(pwd)/data:/app/data \
   group-service
 ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -426,7 +426,7 @@ The `role` field can be `"member"` or `"admin"`. The owner role is immutable: a 
 
 | Code | Name                   | Description                                                     |
 | ---- | ---------------------- | --------------------------------------------------------------- |
-| 400  | InvalidRole            | Role is not `member` or `admin`                                 |
+| 400  | InvalidRole            | Role is not a recognized role (`member`, `admin`, or `owner`)   |
 | 400  | CannotModifyOwner      | Target already holds the owner role                             |
 | 400  | CannotPromoteToOwner   | Cannot promote a member to owner                                |
 | 401  | AuthenticationRequired | Missing or invalid JWT                                          |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -68,11 +68,10 @@ Create a new record in the group's repository.
 
 **Errors:**
 
-| Code | Name                   | Description                         |
-| ---- | ---------------------- | ----------------------------------- |
-| 400  | InvalidRequest         | `repo` does not match the group DID |
-| 401  | AuthenticationRequired | Missing or invalid JWT              |
-| 403  | Forbidden              | Caller lacks member role            |
+| Code | Name                   | Description                                                      |
+| ---- | ---------------------- | ---------------------------------------------------------------- |
+| 401  | AuthenticationRequired | Missing or invalid JWT                                           |
+| 403  | Forbidden              | `repo` does not match the group DID, or caller lacks member role |
 
 **Example:**
 
@@ -134,11 +133,10 @@ Update an existing record or create one at a specific key.
 
 **Errors:**
 
-| Code | Name                   | Description                                   |
-| ---- | ---------------------- | --------------------------------------------- |
-| 400  | InvalidRequest         | `repo` does not match the group DID           |
-| 401  | AuthenticationRequired | Missing or invalid JWT                        |
-| 403  | Forbidden              | Caller lacks required role for this operation |
+| Code | Name                   | Description                                                                           |
+| ---- | ---------------------- | ------------------------------------------------------------------------------------- |
+| 401  | AuthenticationRequired | Missing or invalid JWT                                                                |
+| 403  | Forbidden              | `repo` does not match the group DID, or caller lacks required role for this operation |
 
 **Example:**
 
@@ -191,11 +189,10 @@ Delete a record from the group's repository.
 
 **Errors:**
 
-| Code | Name                   | Description                         |
-| ---- | ---------------------- | ----------------------------------- |
-| 400  | InvalidRequest         | `repo` does not match the group DID |
-| 401  | AuthenticationRequired | Missing or invalid JWT              |
-| 403  | Forbidden              | Caller lacks required role          |
+| Code | Name                   | Description                                                        |
+| ---- | ---------------------- | ------------------------------------------------------------------ |
+| 401  | AuthenticationRequired | Missing or invalid JWT                                             |
+| 403  | Forbidden              | `repo` does not match the group DID, or caller lacks required role |
 
 **Example:**
 
@@ -275,7 +272,7 @@ Add a new member to the group.
 }
 ```
 
-The `role` field must be `"member"` or `"admin"`. Owners cannot be added via this endpoint — use `role.set` to promote an existing member to owner.
+The `role` field must be `"member"` or `"admin"`. The owner role cannot be assigned via any endpoint — it is fixed at registration and is immutable.
 
 **Response (200):**
 
@@ -283,6 +280,7 @@ The `role` field must be `"member"` or `"admin"`. Owners cannot be added via thi
 {
   "memberDid": "did:plc:newmember",
   "role": "member",
+  "addedBy": "did:plc:caller",
   "addedAt": "2026-01-15T12:00:00Z"
 }
 ```
@@ -332,13 +330,12 @@ Remove a member from the group.
 
 **Errors:**
 
-| Code | Name                   | Description                                        |
-| ---- | ---------------------- | -------------------------------------------------- |
-| 400  | CannotRemoveOwner      | Cannot remove a member with the owner role         |
-| 400  | CannotRemoveHigherRole | Target has equal or higher role than caller        |
-| 401  | AuthenticationRequired | Missing or invalid JWT                             |
-| 403  | Forbidden              | Caller lacks admin role (and is not removing self) |
-| 404  | MemberNotFound         | Target is not a group member                       |
+| Code | Name                   | Description                                                                                     |
+| ---- | ---------------------- | ----------------------------------------------------------------------------------------------- |
+| 400  | CannotRemoveOwner      | Cannot remove a member with the owner role                                                      |
+| 401  | AuthenticationRequired | Missing or invalid JWT                                                                          |
+| 403  | Forbidden              | Caller lacks admin role, or target has equal/higher role than caller (and is not removing self) |
+| 404  | MemberNotFound         | Target is not a group member                                                                    |
 
 **Example:**
 
@@ -414,7 +411,7 @@ Change a member's role.
 }
 ```
 
-The `role` field can be `"member"`, `"admin"`, or `"owner"`.
+The `role` field can be `"member"` or `"admin"`. The owner role is immutable: a member cannot be promoted to owner, and an existing owner's role cannot be changed. Ownership transfer is a separate operation (not yet implemented).
 
 **Response (200):**
 
@@ -427,12 +424,14 @@ The `role` field can be `"member"`, `"admin"`, or `"owner"`.
 
 **Errors:**
 
-| Code | Name                   | Description                  |
-| ---- | ---------------------- | ---------------------------- |
-| 400  | LastOwner              | Cannot demote the last owner |
-| 401  | AuthenticationRequired | Missing or invalid JWT       |
-| 403  | Forbidden              | Caller lacks owner role      |
-| 404  | MemberNotFound         | Target is not a group member |
+| Code | Name                   | Description                                                     |
+| ---- | ---------------------- | --------------------------------------------------------------- |
+| 400  | InvalidRole            | Role is not `member` or `admin`                                 |
+| 400  | CannotModifyOwner      | Target already holds the owner role                             |
+| 400  | CannotPromoteToOwner   | Cannot promote a member to owner                                |
+| 401  | AuthenticationRequired | Missing or invalid JWT                                          |
+| 403  | Forbidden              | Caller lacks owner role, or attempted to promote above own role |
+| 404  | MemberNotFound         | Target is not a group member                                    |
 
 **Example:**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,7 +125,7 @@ Roles are compared numerically. A higher level grants all permissions of lower l
 - **Cannot modify equal or higher roles**: An admin cannot remove another admin; only owners can
 - **Cannot assign roles above assignable set**: `member.add` only allows assigning `member` or `admin` — not `owner`
 - **Self-removal always succeeds**: Any member can remove themselves regardless of role
-- **Last-owner protection**: The system prevents demoting or removing the last owner via an atomic transaction check
+- **Owner role is immutable**: `role.set` rejects both promoting a member to owner (`CannotPromoteToOwner`) and changing an existing owner's role (`CannotModifyOwner`); `member.remove` rejects removing an owner (`CannotRemoveOwner`). Each group has exactly one owner (the registrant). Ownership transfer is a separate operation that is not yet implemented.
 - **Author-based record ownership**: `putRecord` and `deleteRecord` check the `group_record_authors` table to determine if the caller authored the record, then select the appropriate operation (`putOwnRecord` / `putAnyRecord` vs `putRecord:profile`, `deleteOwnRecord` vs `deleteAnyRecord`). Members can only edit or delete their own records; editing or deleting another member's record requires admin.
 
 ### RBAC enforcement
@@ -157,6 +157,20 @@ The `RbacChecker` class provides two key methods:
 | `expires_at` | TEXT      | Expiration timestamp |
 
 Indexed on `expires_at` for efficient cleanup.
+
+#### `member_index`
+
+A reverse index of group membership, populated whenever a member is added, removed, or has their role changed. It backs the cross-group `app.certified.groups.membership.list` endpoint (find every group a DID belongs to), which the per-group databases cannot answer since there is no reverse mapping from member to group.
+
+| Column       | Type      | Description                                  |
+| ------------ | --------- | -------------------------------------------- |
+| `member_did` | TEXT (PK) | Member's DID (composite PK with `group_did`) |
+| `group_did`  | TEXT (PK) | Group's DID (composite PK with `member_did`) |
+| `role`       | TEXT      | The member's role in that group              |
+| `added_by`   | TEXT      | DID of the member who added this person      |
+| `added_at`   | TEXT      | ISO timestamp                                |
+
+Indexed on `group_did`.
 
 ### Per-group databases (`data/groups/{hash}.sqlite`)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,7 +6,7 @@ CGS requires:
 
 - **Node.js 22+** runtime
 - **Persistent storage** for SQLite databases (the `DATA_DIR` directory)
-- **Two required environment variables**: `ENCRYPTION_KEY` and `SERVICE_URL`
+- **Three required environment variables**: `ENCRYPTION_KEY`, `SERVICE_URL`, and `GROUP_PDS_URL`
 
 The service exposes a health check at `GET /health` that returns `{"status":"ok"}`.
 
@@ -19,6 +19,7 @@ docker build -t group-service .
 docker run -p 3000:3000 \
   -e SERVICE_URL=https://group-service.example.com \
   -e ENCRYPTION_KEY=$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))") \
+  -e GROUP_PDS_URL=https://pds.example.com \
   -v $(pwd)/data:/app/data \
   group-service
 ```
@@ -39,6 +40,7 @@ CGS is pre-configured for [Railway](https://railway.app/) via `railway.toml`.
    | ---------------- | ---------------------------------------------------------------------------------------- |
    | `SERVICE_URL`    | Full public URL (e.g. `https://your-app.up.railway.app`)                                 |
    | `ENCRYPTION_KEY` | Generate with `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"` |
+   | `GROUP_PDS_URL`  | URL of the PDS where group accounts are created (e.g. `https://pds.example.com`)         |
    | `DATA_DIR`       | `/app/data`                                                                              |
 
    `PORT` is injected automatically by Railway — do not set it manually. All other variables have sensible defaults (see the [environment variables table](../README.md#environment-variables)).
@@ -65,9 +67,16 @@ dockerfilePath = "Dockerfile"
 
 [deploy]
 healthcheckPath = "/health"
-healthcheckTimeout = 10
+healthcheckTimeout = 60
 restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 5
+drainingSeconds = 30
+
+[environments.staging.deploy]
 restartPolicyMaxRetries = 3
+
+[environments.production.deploy]
+restartPolicyMaxRetries = 10
 ```
 
 ### SQLite on Railway

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -43,7 +43,7 @@ CGS is pre-configured for [Railway](https://railway.app/) via `railway.toml`.
    | `GROUP_PDS_URL`  | URL of the PDS where group accounts are created (e.g. `https://pds.example.com`)         |
    | `DATA_DIR`       | `/app/data`                                                                              |
 
-   `PORT` is injected automatically by Railway — do not set it manually. All other variables have sensible defaults (see the [environment variables table](../README.md#environment-variables)).
+   `PORT` is injected automatically by Railway — do not set it manually. The three required variables above must be provided; the remaining optional variables have sensible defaults (see the [environment variables table](../README.md#environment-variables)).
 
    > **Note:** `SERVICE_URL` is written into each group's DID document as the service endpoint. It must be a full public URL (scheme + host) so that atproto-proxy resolution works — a bare hostname will not resolve correctly.
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -363,7 +363,7 @@ await groupAgent.call(
 )
 
 // Change a member's role (requires owner)
-// role can be 'member', 'admin', or 'owner'
+// role can be 'member' or 'admin' (the owner role is immutable)
 await groupAgent.call(
   'app.certified.group.role.set',
   {},

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -464,15 +464,15 @@ Roles are **per-group**, not global. A user can be an owner of one group, a memb
 | _(anyone)_ | Read records (`getRecord`, `listRecords`) — reads go to the PDS, not the group service                       |
 | **member** | Create records, edit/delete own records, upload blobs, list members                                          |
 | **admin**  | Everything above + edit/delete any member's records, edit group profile, add/remove members, query audit log |
-| **owner**  | Everything above + change member roles (promote/demote to any level including owner)                         |
+| **owner**  | Everything above + change member/admin roles (the owner role itself is immutable)                            |
 
 Key constraints:
 
 - Admins can add members at `member` or `admin` level — but not at or above their own role
 - Admins can remove members below their own role level
 - Any member can remove themselves (self-removal)
-- The last owner can't be demoted
-- `member.add` can only assign `member` or `admin` — use `role.set` to promote to `owner`
+- The owner role is immutable — it cannot be demoted, removed, or reassigned
+- `member.add` and `role.set` can only assign `member` or `admin`; the owner role cannot be assigned via any endpoint
 
 ## Reference implementation
 


### PR DESCRIPTION
## Summary

Audit of the CGS docs against the current source (`src/`) surfaced several stale or incorrect claims. This PR corrects them. Docs-only — no runtime changes.

### `docs/api-reference.md`
- **`role.set`**: docs claimed the `owner` role could be assigned and listed a phantom `LastOwner` error. Owner is immutable; actual errors are `CannotModifyOwner` / `CannotPromoteToOwner`. Updated the role field description and error table.
- **repo mismatch** on `createRecord` / `putRecord` / `deleteRecord` returns **403 Forbidden**, not `400 InvalidRequest`.
- **`member.remove`** role-hierarchy violation returns **403**, not a phantom `CannotRemoveHigherRole` (400).
- **`member.add`** response includes `addedBy` (was undocumented).

### `README.md` + `docs/deployment.md`
- Documented the required env var **`GROUP_PDS_URL`** (plus optional `SERVICE_DID`, `GROUP_PDS_INVITE_CODE`) — Docker/Railway examples would fail to boot without it.
- `railway.toml` drift: `healthcheckTimeout` is **60** (not 10), `restartPolicyMaxRetries` is **5** with per-env overrides (not 3).

### `docs/architecture.md`
- Documented the global **`member_index`** table (backs the cross-group `groups.membership.list` endpoint).
- Replaced the inaccurate "last-owner protection / atomic transaction" wording with the actual behaviour: the owner role is fully immutable (`role.set` and `member.remove` both reject it).

### `docs/integration-guide.md` + `CLAUDE.md`
- Fixed the owner-role claims (role-hierarchy table + constraints) that said the owner role could be assigned via `member.add` / `role.set`.

## Test plan
- [x] `prettier --check` passes on all changed docs
- [x] No conflict markers; no trailing whitespace
- [ ] Reviewer sanity-check of the corrected claims against `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified role hierarchy: owner is immutable, created only at group init; role-management endpoints can only assign member/admin and cannot promote or modify owner
  * Refined API error/authorization docs and updated integration & architecture guidance
  * Expanded environment variable and quick-start docs to require GROUP_PDS_URL

* **Chores**
  * Updated deployment/run examples and runtime configuration guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypercerts-org/certified-group-service/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->