### PR TITLE
feat(health): report version and add /xrpc/_health alias

### DIFF
--- a/.changeset/health-version.md
+++ b/.changeset/health-version.md
@@ -1,0 +1,18 @@
+---
+'group-service': minor
+---
+
+The health check now reports the running service version, and the same check is also reachable at `/xrpc/_health`.
+
+**Affects:** Client app developers, Operators
+
+**Client app developers:**
+
+- `GET /health` response gains two fields: `service` (always `"group-service"`) and `version` (e.g. `"0.1.0+90d10b96"`). The existing `status: "ok"` / `503 { status: "error", message: "database unreachable" }` behaviour is unchanged, so existing health checks keep working.
+- A new `GET /xrpc/_health` route returns the identical body to `/health` (including the same 503-on-DB-failure semantics). This mirrors the upstream PDS convention of exposing `/xrpc/_health`; the group service has no upstream PDS, so it serves the route itself. Note it returns the full `{ status, service, version }` object, not the bare `{ version }` some atproto services return.
+
+**Operators:**
+
+- The reported version resolves in this order: the `CGS_VERSION` env var, then a `.cgs-version` file written at image-build time, then the `version` field in `package.json`. Set `CGS_VERSION` to override the stamp (e.g. `CGS_VERSION=0.1.0+abcdef01`).
+- On Railway, the Docker build stamps `<package.json version>+<short commit sha>` automatically from `RAILWAY_GIT_COMMIT_SHA` — no action needed.
+- For local `docker build`, run `./scripts/stamp-version.sh` first to write `.cgs-version`; the build fails with `ERROR: .cgs-version not found` otherwise. `.cgs-version` is gitignored.

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,9 @@ MAX_BLOB_SIZE=5242880
 # Logging
 # Log level: trace, debug, info, warn, error, fatal
 LOG_LEVEL=info
+
+# Version
+# OPTIONAL operator override for the version string reported by /health and
+# /xrpc/_health. Leave unset: the version is normally stamped at build time
+# (.cgs-version) or read from package.json. Only set this to force a value.
+# CGS_VERSION=0.1.0+abcdef01

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 dist/
 coverage/
 *.tsbuildinfo
+# version stamp written at build time (scripts/stamp-version.sh / Dockerfile)
+.cgs-version
 .env
 .env.*
 !.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY . .
+# Stamp the group service version into .cgs-version. Railway injects
+# RAILWAY_GIT_COMMIT_SHA; for local builds, run ./scripts/stamp-version.sh
+# first so a .cgs-version is already present (resolve-version.sh validates it).
+ARG RAILWAY_GIT_COMMIT_SHA
+RUN ./scripts/resolve-version.sh
 RUN pnpm build
 RUN pnpm prune --prod
 
@@ -15,6 +20,7 @@ WORKDIR /app
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
+COPY --from=builder /app/.cgs-version ./
 COPY --from=builder /app/lexicons ./lexicons
 RUN mkdir -p /app/data/groups
 EXPOSE 3000

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-All endpoints (except `/health`) require authentication via a signed JWT in the `Authorization: Bearer <token>` header. The JWT must include:
+All endpoints (except `/health` and `/xrpc/_health`) require authentication via a signed JWT in the `Authorization: Bearer <token>` header. The JWT must include:
 
 - `iss` — the caller's DID
 - `aud` — the **service DID** (its standard RFC 7519 meaning: the audience is the service receiving the request)
@@ -41,9 +41,11 @@ There is no `Sunset` header yet, as the removal date is undecided.
 
 ## Health check
 
-### `GET /health`
+### `GET /health` / `GET /xrpc/_health`
 
-Returns service health status. No authentication required.
+Returns service health status. No authentication required. Both paths return
+the identical body; `/xrpc/_health` exists for parity with the upstream PDS
+convention.
 
 **Response:**
 
@@ -52,8 +54,13 @@ Returns service health status. No authentication required.
 ```
 
 ```json
-{ "status": "ok" }
+{ "status": "ok", "service": "group-service", "version": "0.1.0+90d10b96" }
 ```
+
+The `version` is resolved from the `CGS_VERSION` env var, a build-time
+`.cgs-version` file, or `package.json` (in that order). When the global
+database is unreachable, both endpoints return `503` with
+`{ "status": "error", "message": "database unreachable" }`.
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,7 +8,7 @@ CGS requires:
 - **Persistent storage** for SQLite databases (the `DATA_DIR` directory)
 - **Three required environment variables**: `ENCRYPTION_KEY`, `SERVICE_URL`, and `GROUP_PDS_URL`
 
-The service exposes a health check at `GET /health` that returns `{"status":"ok"}`.
+The service exposes a health check at `GET /health` (also reachable as `GET /xrpc/_health`) that returns `{"status":"ok","service":"group-service","version":"..."}`.
 
 ## Docker
 
@@ -54,7 +54,7 @@ CGS is pre-configured for [Railway](https://railway.app/) via `railway.toml`.
 
 4. **Deploy** — Railway auto-detects the Dockerfile, builds, and deploys
 
-5. **Verify** — hit `https://your-app.up.railway.app/health` and confirm `{"status":"ok"}`
+5. **Verify** — hit `https://your-app.up.railway.app/health` and confirm `status` is `"ok"` and a `version` is reported
 
 ### Railway configuration
 

--- a/e2e/step-definitions/common.steps.ts
+++ b/e2e/step-definitions/common.steps.ts
@@ -67,10 +67,11 @@ Given('the test accounts are resolved', async function (this: CgsWorld) {
   }
 })
 
-// Cucumber Expressions treat `/` as an alternation separator; String.raw with
-// `\/` passes a literal escaped slash so "/health" isn't read as an alternative.
-When(String.raw`the CGS \/health endpoint is queried`, async function (this: CgsWorld) {
-  const res = await fetch(`${this.env.cgsUrl}/health`)
+// Cucumber Expressions treat `/` as an alternation separator; the {string}
+// parameter takes the quoted path verbatim, so "/health" and "/xrpc/_health"
+// both flow through this one step.
+When('the CGS {string} endpoint is queried', async function (this: CgsWorld, path: string) {
+  const res = await fetch(`${this.env.cgsUrl}${path}`)
   this.lastHttpStatus = res.status
   // Record the raw body and parse defensively so a non-JSON error response
   // (e.g. an HTML 502 from an edge) doesn't throw, and assertion failures can
@@ -94,6 +95,31 @@ Then('the response status is {int}', function (this: CgsWorld, expected: number)
 Then('the response status field is {string}', function (this: CgsWorld, expected: string) {
   const status = (this.lastHttpJson as { status?: string } | undefined)?.status
   assert.equal(status, expected, `expected status field "${expected}", got "${status}"`)
+})
+
+Then(
+  'the response {string} field is {string}',
+  function (this: CgsWorld, field: string, expected: string) {
+    const actual = this.lastHttpJson?.[field]
+    assert.equal(
+      actual,
+      expected,
+      `expected ${field} field "${expected}", got "${String(actual)}" (${this.lastHttpBody})`,
+    )
+  },
+)
+
+Then('the response contains a version string', function (this: CgsWorld) {
+  const version = (this.lastHttpJson as { version?: unknown } | undefined)?.version
+  assert.equal(
+    typeof version,
+    'string',
+    `expected a version string, got ${String(version)} (${this.lastHttpBody})`,
+  )
+  assert.ok(
+    (version as string).length > 0,
+    `expected a non-empty version string (${this.lastHttpBody})`,
+  )
 })
 
 Then('the response error is {string}', function (this: CgsWorld, expected: string) {

--- a/features/health.feature
+++ b/features/health.feature
@@ -1,10 +1,21 @@
 Feature: Health
   The group service exposes an unauthenticated GET /health that reports
-  service liveness (and database reachability). This is the only endpoint
-  that does not require an atproto service-auth JWT.
+  service liveness (and database reachability), plus an /xrpc/_health alias
+  that returns the same body. These are the only endpoints that do not
+  require an atproto service-auth JWT.
 
   @health
-  Scenario: /health reports ok
-    When the CGS /health endpoint is queried
+  Scenario: /health reports ok with service and version
+    When the CGS "/health" endpoint is queried
     Then the response status is 200
     And the response status field is "ok"
+    And the response "service" field is "group-service"
+    And the response contains a version string
+
+  @health
+  Scenario: /xrpc/_health mirrors /health
+    When the CGS "/xrpc/_health" endpoint is queried
+    Then the response status is 200
+    And the response status field is "ok"
+    And the response "service" field is "group-service"
+    And the response contains a version string

--- a/scripts/resolve-version.sh
+++ b/scripts/resolve-version.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Resolve the group service version and write it to .cgs-version in the
+# current directory. Used by the Dockerfile during image build.
+#
+# Sources (first non-empty wins):
+#   1. RAILWAY_GIT_COMMIT_SHA env var (injected by Railway at build time)
+#   2. .cgs-version file already present (written by stamp-version.sh)
+#   3. Fails with an actionable error
+set -e
+
+if [ -n "$RAILWAY_GIT_COMMIT_SHA" ]; then
+  VERSION=$(node -p "require('./package.json').version")
+  echo "$VERSION+$(echo "$RAILWAY_GIT_COMMIT_SHA" | cut -c1-8)" > .cgs-version
+  exit 0
+fi
+
+if [ ! -f .cgs-version ]; then
+  echo "ERROR: .cgs-version not found. Run ./scripts/stamp-version.sh before building." >&2
+  exit 1
+fi
+
+if [ ! -s .cgs-version ]; then
+  echo "ERROR: .cgs-version exists but is empty. Re-run ./scripts/stamp-version.sh." >&2
+  exit 1
+fi

--- a/scripts/stamp-version.sh
+++ b/scripts/stamp-version.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Write .cgs-version at the repo root for Docker builds to pick up.
+# Run manually before a local `docker build`. The Dockerfile copies this
+# file if it exists; Railway uses RAILWAY_GIT_COMMIT_SHA instead.
+set -e
+VERSION=$(node -p "require('./package.json').version")
+SHA=$(git rev-parse HEAD 2>/dev/null || echo "")
+if [ -n "$SHA" ]; then
+  VERSION="$VERSION+$(echo "$SHA" | cut -c1-8)"
+fi
+echo "$VERSION" > .cgs-version
+echo "$VERSION"

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,0 +1,25 @@
+import type { Request, Response } from 'express'
+import type { Kysely } from 'kysely'
+import type { GlobalDatabase } from './db/schema.js'
+import { getVersion } from './version.js'
+
+/**
+ * Build the health-check handler shared by `/health` and `/xrpc/_health`.
+ *
+ * Reports `{ status, service, version }` on success and a 503 with
+ * `{ status: 'error', message }` when the global database is unreachable.
+ * The version is resolved once at startup, since it is fixed for the
+ * lifetime of the process (see {@link getVersion}).
+ */
+export function createHealthHandler(globalDb: Kysely<GlobalDatabase>) {
+  const version = getVersion()
+
+  return async (_req: Request, res: Response): Promise<void> => {
+    try {
+      await globalDb.selectFrom('groups').select('did').limit(1).execute()
+      res.json({ status: 'ok', service: 'group-service', version })
+    } catch {
+      res.status(503).json({ status: 'error', message: 'database unreachable' })
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { NonceCache } from './auth/nonce.js'
 import { RbacChecker } from './rbac/check.js'
 import { registerXrpcMethods } from './api/index.js'
 import { createFallbackErrorHandler } from './api/error-handler.js'
+import { createHealthHandler } from './health.js'
 import { runGlobalMigrations } from './db/migrate.js'
 import { openSqliteDb } from './db/sqlite.js'
 import { GroupDbPool } from './db/group-db-pool.js'
@@ -84,15 +85,14 @@ async function main() {
     logger,
   }
 
-  // Health check (unchanged)
-  app.get('/health', async (_req, res) => {
-    try {
-      await globalDb.selectFrom('groups').select('did').limit(1).execute()
-      res.json({ status: 'ok' })
-    } catch {
-      res.status(503).json({ status: 'error', message: 'database unreachable' })
-    }
-  })
+  // Health check. Reports liveness, service name and version, gated on a
+  // probe of the global DB. `/xrpc/_health` mirrors `/health` — the upstream
+  // PDS exposes _health from its own code, but the group service has no such
+  // upstream, so we serve it ourselves. It must be registered before the
+  // XRPC router so it wins over the catch-all /xrpc/* handler.
+  const healthHandler = createHealthHandler(globalDb)
+  app.get('/health', healthHandler)
+  app.get('/xrpc/_health', healthHandler)
 
   // XRPC server — handles all /xrpc/* routes, including group.register and
   // group.import (service-auth methods) and per-group methods

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// src/version.ts → dist/version.js: both sit one level under the repo root,
+// so the root is always the parent directory of this module.
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+/**
+ * Resolve the group service version string.
+ *
+ * Precedence:
+ *   1. `CGS_VERSION` env var (operator override, e.g. `0.1.0+abcdef01`)
+ *   2. `.cgs-version` file written at Docker build time
+ *   3. `version` field from the root `package.json` (dev / non-Docker)
+ *
+ * Throws if none of the above can be resolved — this indicates a broken
+ * build or missing repo root, not a condition to silently degrade from.
+ */
+export function getVersion(): string {
+  if (process.env.CGS_VERSION) {
+    return process.env.CGS_VERSION
+  }
+
+  try {
+    const v = readFileSync(join(ROOT, '.cgs-version'), 'utf8').trim()
+    if (v) return v
+  } catch {
+    // .cgs-version not present — fall through to package.json
+  }
+
+  const pkgPath = join(ROOT, 'package.json')
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+  return pkg.version
+}

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -3,41 +3,46 @@ import express from 'express'
 import request from 'supertest'
 import type { Kysely } from 'kysely'
 import type { GlobalDatabase } from '../src/db/schema.js'
+import { createHealthHandler } from '../src/health.js'
 import { createTestGlobalDb } from './helpers/test-db.js'
 
-describe('GET /health', () => {
+// Pin the version so the body assertions are deterministic, independent of
+// package.json / .cgs-version (see src/version.ts precedence).
+const PINNED_VERSION = '9.9.9+testtest'
+
+describe.each(['/health', '/xrpc/_health'])('GET %s', (path) => {
   let globalDb: Kysely<GlobalDatabase>
   let app: express.Express
 
   beforeEach(async () => {
+    process.env.CGS_VERSION = PINNED_VERSION
     const testGlobal = await createTestGlobalDb()
     globalDb = testGlobal.db
     app = express()
-    app.get('/health', async (_req, res) => {
-      try {
-        await globalDb.selectFrom('groups').select('did').limit(1).execute()
-        res.json({ status: 'ok' })
-      } catch {
-        res.status(503).json({ status: 'error', message: 'database unreachable' })
-      }
-    })
+    // Both routes share the same handler in production (src/index.ts).
+    app.get(path, createHealthHandler(globalDb))
   })
 
   afterEach(async () => {
+    delete process.env.CGS_VERSION
     try {
       await globalDb.destroy()
     } catch {}
   })
 
-  it('returns 200 when DB is healthy', async () => {
-    const res = await request(app).get('/health')
+  it('returns 200 with status, service and version when DB is healthy', async () => {
+    const res = await request(app).get(path)
     expect(res.status).toBe(200)
-    expect(res.body).toEqual({ status: 'ok' })
+    expect(res.body).toEqual({
+      status: 'ok',
+      service: 'group-service',
+      version: PINNED_VERSION,
+    })
   })
 
   it('returns 503 when DB is destroyed', async () => {
     await globalDb.destroy()
-    const res = await request(app).get('/health')
+    const res = await request(app).get(path)
     expect(res.status).toBe(503)
     expect(res.body).toEqual({
       status: 'error',

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { writeFileSync, rmSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { getVersion } from '../src/version.js'
+
+// Mirror src/version.ts: repo root is the parent of the src/ (or dist/) dir.
+// tests/ sits at the repo root, so root is one level up from this file.
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const VERSION_FILE = join(ROOT, '.cgs-version')
+const PKG_VERSION = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')).version
+
+describe('getVersion', () => {
+  afterEach(() => {
+    delete process.env.CGS_VERSION
+    rmSync(VERSION_FILE, { force: true })
+  })
+
+  it('prefers the CGS_VERSION env override', () => {
+    process.env.CGS_VERSION = '1.2.3+deadbeef'
+    // A .cgs-version file present must not win over the env var.
+    writeFileSync(VERSION_FILE, '0.0.0+fromfile')
+    expect(getVersion()).toBe('1.2.3+deadbeef')
+  })
+
+  it('falls back to the .cgs-version file when no env override', () => {
+    writeFileSync(VERSION_FILE, '4.5.6+abcd1234\n')
+    expect(getVersion()).toBe('4.5.6+abcd1234')
+  })
+
+  it('ignores an empty .cgs-version file and falls back to package.json', () => {
+    writeFileSync(VERSION_FILE, '   \n')
+    expect(getVersion()).toBe(PKG_VERSION)
+  })
+
+  it('falls back to package.json version when nothing else is set', () => {
+    expect(getVersion()).toBe(PKG_VERSION)
+  })
+})


### PR DESCRIPTION
## Summary

Make `/health` report a version string, mirroring `../ePDS` exactly, and (per review discussion) add an `/xrpc/_health` alias returning the **identical** body.

- **Version resolution** ported from ePDS (`CGS`-prefixed): `CGS_VERSION` env → `.cgs-version` build stamp → `package.json` (`src/version.ts`). `scripts/resolve-version.sh` + `stamp-version.sh`; the Dockerfile stamps `<version>+<sha8>` from `RAILWAY_GIT_COMMIT_SHA`; `.cgs-version` is gitignored.
- **Shared handler** extracted to `src/health.ts` (`createHealthHandler`), used by both routes **and** the unit test — removing the duplicated inline handler the test previously carried.
- `/health` and `/xrpc/_health` → `{ status, service: "group-service", version }`; `503 { status: "error", message }` on DB failure. `/xrpc/_health` is registered before the XRPC catch-all router so it wins.

### Why `/xrpc/_health` isn't free here
The PDS gets `/xrpc/_health` from upstream `@atproto/pds`. The group service has no upstream PDS in-process, so it serves the route itself. By design it returns the full `{ status, service, version }` object (not the bare `{ version }` some atproto services return) — documented in the changeset.

## Changes
- `src/version.ts`, `src/health.ts` (new); `src/index.ts` wiring
- `scripts/resolve-version.sh`, `scripts/stamp-version.sh` (new); `Dockerfile` stamp step; `.gitignore` `.cgs-version`
- `.env.example`: commented-out, clearly-optional `CGS_VERSION`
- e2e: parameterized path step + `service`/`version` assertions + `/xrpc/_health` scenario (`features/health.feature`, `common.steps.ts`)
- Docs: `docs/api-reference.md`, `docs/deployment.md`
- Tests: `tests/version.test.ts` (new, 4 precedence branches); `tests/health.test.ts` rewritten to use the shared handler over both paths
- Changeset: `.changeset/health-version.md` (minor; affects client app developers + operators)

## Testing
- `pnpm test` — 268/268 pass
- `pnpm run lint` clean; e2e `tsc --noEmit` clean; repo-wide `prettier --check .` clean
- Booted the server and curled both routes: identical 200 bodies; a real XRPC method (`member.list`) still returns 401, confirming `/xrpc/_health` doesn't shadow the router

🤖 Generated with [Claude Code](https://claude.com/claude-code)