### PR TITLE
fix(ci): stamp version in publish workflow before docker build

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -16,6 +16,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      # The Dockerfile runs scripts/resolve-version.sh, which needs a
+      # .cgs-version in the build context (Railway injects the SHA instead,
+      # but GitHub Actions doesn't). Stamp it before building.
+      - name: Stamp version
+        run: ./scripts/stamp-version.sh
+
       - uses: docker/setup-qemu-action@v3
 
       - name: Setup Blacksmith Builder

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -14,7 +14,7 @@ jobs:
   publish:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -26,18 +26,18 @@ jobs:
       - name: Stamp version
         run: ./scripts/stamp-version.sh
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         id: meta
         with:
           images: ghcr.io/${{ github.repository_owner }}/group-service
@@ -47,7 +47,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
 
-      - uses: useblacksmith/build-push-action@v2
+      - uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Problem

The container-publish workflow ([run #27154323287](https://github.com/hypercerts-org/certified-group-service/actions/runs/27154323287)) failed with the opaque:

```
buildx failed with: /src/solver/jobs.go:1182
```

The real error was deeper in the buildkit output:

```
#19 0.060 ERROR: .cgs-version not found. Run ./scripts/stamp-version.sh before building.
#19 ERROR: process "/bin/sh -c ./scripts/resolve-version.sh" did not complete successfully: exit code: 1
```

The Dockerfile runs `scripts/resolve-version.sh`, which resolves the version from one of:
1. `RAILWAY_GIT_COMMIT_SHA` (Railway only), or
2. a `.cgs-version` file in the build context (written by `stamp-version.sh`).

The GHCR publish workflow had **neither** — no Railway env var, no stamp step, and `.cgs-version` is gitignored so checkout doesn't carry one. So the script exited 1 and buildx aborted.

This is a gap in the publish path: the version-stamping feature (added in `a906bd8 feat(health): report version`) wired up the Railway and local-`docker build` paths but missed the GHCR publish workflow.

## Fix

Add a `setup-node` + `stamp-version.sh` step before the build. `node 22` is pinned (matching `ci.yml`'s exact action SHA) rather than relying on the runner's ambient node, per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)