### PR TITLE
prepare for release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # group-service
 
+## 0.2.1
+
+### Patch Changes
+
+- Republish the container image. The v0.2.0 image build failed (its version-stamping step had no `.cgs-version` to read), so no `ghcr.io/hypercerts-org/group-service` tags were published for v0.2.0. The publish workflow now stamps the version before building; v0.2.1 is the first release to produce a working image. No functional change to the service versus what v0.2.0 would have shipped.
+
 ## 0.2.0
 
 ### Who should read this release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2.1
 
+### Patch Changes
+
 - Republish the container image. The v0.2.0 image build failed (its version-stamping step had no `.cgs-version` to read), so no `ghcr.io/hypercerts-org/group-service` tags were published for v0.2.0. The publish workflow now stamps the version before building; v0.2.1 is the first release to produce a working image. No functional change to the service versus what v0.2.0 would have shipped.
 
   **Affects:** Operators

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## 0.2.1
 
-### Patch Changes
-
-- Republish the container image. The v0.2.0 image build failed (its version-stamping step had no `.cgs-version` to read), so no `ghcr.io/hypercerts-org/group-service` tags were published for v0.2.0. The publish workflow now stamps the version before building; v0.2.1 is the first release to produce a working image. No functional change to the service versus what v0.2.0 would have shipped.
+Republish the container image. The v0.2.0 image build failed (its version-stamping step had no `.cgs-version` to read), so no `ghcr.io/hypercerts-org/group-service` tags were published for v0.2.0. The publish workflow now stamps the version before building; v0.2.1 is the first release to produce a working image. No functional change to the service versus what v0.2.0 would have shipped.
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.2.1
 
-Republish the container image. The v0.2.0 image build failed (its version-stamping step had no `.cgs-version` to read), so no `ghcr.io/hypercerts-org/group-service` tags were published for v0.2.0. The publish workflow now stamps the version before building; v0.2.1 is the first release to produce a working image. No functional change to the service versus what v0.2.0 would have shipped.
+- Republish the container image. The v0.2.0 image build failed (its version-stamping step had no `.cgs-version` to read), so no `ghcr.io/hypercerts-org/group-service` tags were published for v0.2.0. The publish workflow now stamps the version before building; v0.2.1 is the first release to produce a working image. No functional change to the service versus what v0.2.0 would have shipped.
+
+  **Affects:** Operators
 
 ## 0.2.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "group-service",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Group-governed PDS for atproto",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Bump `group-service` to **v0.2.1** to republish the container image.

## Why

The v0.2.0 image build failed (its version-stamping step had no `.cgs-version` to read — surfaced as the opaque `buildx failed with: /src/solver/jobs.go:1182`), so **no `ghcr.io/hypercerts-org/group-service` tags were ever published for v0.2.0**. Only `:main` exists. The publish-workflow fix landed in #41; v0.2.1 is the first release that will produce a working image.

## What this triggers

This PR's head branch is `changeset-release/main`, so on merge the release workflow's release job runs. With no pending changesets and `package.json` ahead of the last tag, `changesets/action` runs `pnpm release` (`changeset tag`), which:

1. Creates the **`v0.2.1`** git tag + GitHub Release.
2. The `v0.2.1` tag push triggers `publish-image.yml`, building and pushing `:0.2.1`, `:0.2`, `:0`, `:latest` with the fix.

## Notes

- No functional change to the service versus what v0.2.0 would have shipped — this is purely a republish.
- CHANGELOG entry is hand-written (no changeset). The `version-packages` step (which generates the "Who should read this release" block) does **not** run on this path; only `changeset tag` runs. Fine for a patch with no per-audience sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)