### PR TITLE
feat(demo): API-key support + Railway deploy config

### DIFF
--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .env
+dist-server

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,0 +1,24 @@
+# Demo app (React SPA + Express BFF) — single-container image.
+# The BFF serves both /api and the built client (see server/index.ts).
+FROM node:22-slim AS builder
+WORKDIR /app
+RUN corepack enable
+# The demo is not a pnpm workspace member, so install with --ignore-workspace
+# (otherwise pnpm treats the repo root workspace as context and skips it).
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile --ignore-workspace
+COPY . .
+# vite build -> dist/ (client), tsc -p tsconfig.server.json -> dist-server/ (BFF)
+RUN pnpm build
+RUN pnpm prune --prod --ignore-workspace
+
+FROM node:22-slim
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/dist-server ./dist-server
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./
+# The server listens on PORT (Railway's convention) then BFF_PORT then 3001.
+EXPOSE 3001
+CMD ["node", "dist-server/index.js"]

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,103 @@
+# Group Service Demo
+
+A small reference app showing how to integrate with the
+[Certified Group Service](../) (CGS) from a web app. It's a **React SPA** with a
+thin **backend-for-frontend (BFF)** that logs the user in via AT Protocol OAuth
+and forwards XRPC calls to the group service through the `atproto-proxy` pattern.
+
+It is a teaching/demo app, not production code — but it exercises the real CGS
+API end to end.
+
+## What it demonstrates
+
+Each page maps to part of the CGS surface:
+
+| Page          | What it shows                                                                      |
+|---------------|------------------------------------------------------------------------------------|
+| **Login**     | AT Protocol OAuth against the ePDS; the BFF holds the session.                     |
+| **Register**  | Create a group (`group.register`) or import an existing account.                   |
+| **Dashboard** | The active group and your role in it.                                              |
+| **Records**   | Create / update / delete records via `app.certified.group.repo.*`.                 |
+| **Upload**    | Upload a blob to the group's repo.                                                 |
+| **Audit**     | Query the group's audit log.                                                       |
+| **API Keys**  | Mint scope-limited API keys, show the secret once, list/revoke, and **use** a key. |
+
+The **API Keys** page is the most complete example of the key framework: it mints
+a key with a scope picker (read `rpc:` scopes, record-write `repo:` scopes, blob
+`blob:` scopes), shows the plaintext exactly once, lists/revokes keys, and then
+**calls `member.list` with the key via the `X-API-Key` header** — no owner
+session — so you can watch a key work on its own (and get a `403` if it lacks the
+scope).
+
+## Architecture
+
+```
+Browser (React SPA, Vite)
+   │  /api/*        → BFF
+   ▼
+BFF (Express, server/)
+   │  OAuth session + atproto-proxy → user's PDS → Group Service
+   │  /api/keys/call → direct X-API-Key call to the Group Service
+   ▼
+Group Service (CGS) ──▶ Group's PDS
+```
+
+- In **dev**, Vite serves the SPA (port 5173) and proxies `/api` to the BFF
+  (port 3001).
+- In **production** (single container), the BFF also serves the built SPA, so one
+  process serves both the UI and the API.
+
+## Local development
+
+> **Note:** the demo is **not** a member of the repo's pnpm workspace, so install
+> with `--ignore-workspace` — otherwise pnpm treats the repo root as the workspace
+> and skips the demo's dependencies.
+
+```bash
+cd demo
+pnpm install --ignore-workspace
+cp .env.example .env   # then fill in the values below
+pnpm dev               # runs the BFF (tsx watch) and Vite together
+```
+
+Open the Vite URL it prints (default http://localhost:5173).
+
+### Environment (`.env`)
+
+| Variable             | Purpose                                                                       |
+| -------------------- | ----------------------------------------------------------------------------- |
+| `GROUP_SERVICE_URL`  | CGS base URL, e.g. `https://dev.groups.certified.app`.                         |
+| `GROUP_SERVICE_DID`  | CGS DID (the JWT `aud`), e.g. `did:web:dev.groups.certified.app`.              |
+| `EPDS_URL`           | The ePDS users authenticate against, e.g. `https://epds1.test.certified.app`. |
+| `SESSION_SECRET`     | Random string for the BFF session cookie (`openssl rand -hex 32`).            |
+| `OAUTH_CLIENT_ID`    | URL of the OAuth client metadata — **must be publicly reachable** so the ePDS can fetch it (e.g. `https://<your-domain>/client-metadata.json`). |
+| `OAUTH_REDIRECT_URI` | OAuth callback, e.g. `https://<your-domain>/api/oauth/callback`.               |
+
+Because OAuth requires the ePDS to fetch your `client-metadata.json`, the demo
+needs a **publicly reachable domain** to fully log in — pure `localhost` won't
+complete the OAuth round-trip.
+
+## Production build
+
+```bash
+pnpm build    # vite build → dist/ (client) + tsc → dist-server/ (BFF)
+pnpm start    # node dist-server/index.js  (set NODE_ENV=production)
+```
+
+With `NODE_ENV=production`, the BFF serves the built SPA from `dist/` (override
+with `CLIENT_DIST`) and listens on `PORT` (falling back to `BFF_PORT`, then 3001).
+
+## Deploying to Railway
+
+The demo deploys as its **own** Railway service (separate from the group service,
+which uses the repo-root `railway.toml`):
+
+1. Create a new Railway service in the project, pointing at this repo.
+2. Set its **Root Directory** to `demo` and its **config path** to
+   [`railway-demo.toml`](../railway-demo.toml) (at the repo root).
+3. Set the service variables listed under [Environment](#environment-env) — with
+   `OAUTH_CLIENT_ID` / `OAUTH_REDIRECT_URI` pointing at the service's Railway
+   domain.
+
+Railway builds the `demo/Dockerfile` and injects `PORT`; the BFF serves both the
+API and the SPA. The healthcheck path is `/api/health`.

--- a/demo/server/index.ts
+++ b/demo/server/index.ts
@@ -6,6 +6,7 @@ import authRoutes from './routes/auth.js'
 import proxyRoutes from './routes/proxy.js'
 import uploadRoutes from './routes/upload.js'
 import registerRoutes from './routes/register.js'
+import keysRoutes from './routes/keys.js'
 
 const app = express()
 const PORT = parseInt(process.env.BFF_PORT || '3001', 10)
@@ -57,6 +58,7 @@ app.get('/client-metadata.json', (_req, res) => {
 app.use('/api', authRoutes)
 app.use('/api/proxy', proxyRoutes)
 app.use('/api/register', registerRoutes)
+app.use('/api/keys', keysRoutes)
 
 // Health check
 app.get('/api/health', (_req, res) => res.json({ ok: true }))

--- a/demo/server/index.ts
+++ b/demo/server/index.ts
@@ -1,4 +1,6 @@
 import './env.js'
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import express from 'express'
 import session from 'express-session'
 import cors from 'cors'
@@ -9,7 +11,8 @@ import registerRoutes from './routes/register.js'
 import keysRoutes from './routes/keys.js'
 
 const app = express()
-const PORT = parseInt(process.env.BFF_PORT || '3001', 10)
+// PORT is Railway's convention; BFF_PORT is the local dev override; 3001 default.
+const PORT = parseInt(process.env.PORT || process.env.BFF_PORT || '3001', 10)
 
 const sessionSecret = process.env.SESSION_SECRET
 if (!sessionSecret) throw new Error('SESSION_SECRET must be set')
@@ -62,6 +65,22 @@ app.use('/api/keys', keysRoutes)
 
 // Health check
 app.get('/api/health', (_req, res) => res.json({ ok: true }))
+
+// Serve the built SPA in production. In dev, Vite serves the client (port 5173)
+// and proxies /api here, so this block is inactive. On a single-process deploy
+// (e.g. Railway) the BFF serves both the API and the built client. The client
+// dist defaults to ../dist relative to the compiled server (dist-server/),
+// overridable with CLIENT_DIST.
+if (process.env.NODE_ENV === 'production') {
+  const here = fileURLToPath(new URL('.', import.meta.url))
+  const clientDist = process.env.CLIENT_DIST || join(here, '..', 'dist')
+  app.use(express.static(clientDist))
+  // SPA fallback: any non-/api route returns index.html so client-side routing
+  // (react-router) works on deep links / refresh.
+  app.get(/^(?!\/api\/).*/, (_req, res) => {
+    res.sendFile(join(clientDist, 'index.html'))
+  })
+}
 
 app.listen(PORT, () => {
   console.log(`BFF server running on http://localhost:${PORT}`)

--- a/demo/server/index.ts
+++ b/demo/server/index.ts
@@ -75,9 +75,10 @@ if (process.env.NODE_ENV === 'production') {
   const here = fileURLToPath(new URL('.', import.meta.url))
   const clientDist = process.env.CLIENT_DIST || join(here, '..', 'dist')
   app.use(express.static(clientDist))
-  // SPA fallback: any non-/api route returns index.html so client-side routing
-  // (react-router) works on deep links / refresh.
-  app.get(/^(?!\/api\/).*/, (_req, res) => {
+  // SPA fallback: any non-API route returns index.html so client-side routing
+  // (react-router) works on deep links / refresh. Exclude both `/api` and
+  // `/api/*` so unknown API paths return a real 404 instead of the SPA shell.
+  app.get(/^(?!\/api(\/|$)).*/, (_req, res) => {
     res.sendFile(join(clientDist, 'index.html'))
   })
 }

--- a/demo/server/routes/keys.ts
+++ b/demo/server/routes/keys.ts
@@ -2,6 +2,10 @@ import { Router } from 'express'
 
 const router = Router()
 
+const ALLOWED_METHODS = ['GET', 'POST'] as const
+type AllowedMethod = (typeof ALLOWED_METHODS)[number]
+const UPSTREAM_TIMEOUT_MS = 15_000
+
 /**
  * POST /api/keys/call — exercise an API key.
  *
@@ -26,6 +30,13 @@ router.post('/call', async (req, res) => {
     return res.status(400).json({ error: 'key, nsid and repo are required' })
   }
 
+  // Validate `method` at runtime — the TS type is not enforced on the wire, and
+  // this route must not forward arbitrary verbs upstream.
+  if (!ALLOWED_METHODS.includes(method as AllowedMethod)) {
+    return res.status(400).json({ error: `method must be one of ${ALLOWED_METHODS.join(', ')}` })
+  }
+  const verb = method as AllowedMethod
+
   const base = process.env.GROUP_SERVICE_URL
   if (!base) {
     return res.status(500).json({ error: 'GROUP_SERVICE_URL not configured' })
@@ -33,14 +44,18 @@ router.post('/call', async (req, res) => {
 
   const url = `${base.replace(/\/$/, '')}/xrpc/${nsid}?repo=${encodeURIComponent(repo)}`
 
+  // Bound the upstream call so a hung group service can't tie up a worker.
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS)
   try {
     const headers: Record<string, string> = { 'X-API-Key': key }
-    if (method === 'POST' && body !== undefined) headers['Content-Type'] = 'application/json'
+    if (verb === 'POST' && body !== undefined) headers['Content-Type'] = 'application/json'
 
     const upstream = await fetch(url, {
-      method,
+      method: verb,
       headers,
-      body: method === 'POST' && body !== undefined ? JSON.stringify(body) : undefined,
+      body: verb === 'POST' && body !== undefined ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
     })
 
     const text = await upstream.text()
@@ -55,7 +70,12 @@ router.post('/call', async (req, res) => {
     // show both a success and a scope-denied (403) outcome.
     res.json({ status: upstream.status, data })
   } catch (err: any) {
+    if (err?.name === 'AbortError') {
+      return res.status(504).json({ error: 'group service did not respond in time' })
+    }
     res.status(502).json({ error: err?.message || 'API-key call failed' })
+  } finally {
+    clearTimeout(timer)
   }
 })
 

--- a/demo/server/routes/keys.ts
+++ b/demo/server/routes/keys.ts
@@ -1,0 +1,62 @@
+import { Router } from 'express'
+
+const router = Router()
+
+/**
+ * POST /api/keys/call — exercise an API key.
+ *
+ * Unlike the proxy route, this path uses NO owner session and NO atproto-proxy:
+ * the API key IS the credential. The BFF makes a direct call to the group
+ * service with the `X-API-Key` header so the demo can show that a key works on
+ * its own. `repo` rides the querystring — required on the key path, even for
+ * write procedures (the service resolves the group before the body is parsed).
+ *
+ * Body: { key, nsid, repo, method?, body? }
+ */
+router.post('/call', async (req, res) => {
+  const { key, nsid, repo, method = 'GET', body } = req.body as {
+    key?: string
+    nsid?: string
+    repo?: string
+    method?: 'GET' | 'POST'
+    body?: unknown
+  }
+
+  if (!key || !nsid || !repo) {
+    return res.status(400).json({ error: 'key, nsid and repo are required' })
+  }
+
+  const base = process.env.GROUP_SERVICE_URL
+  if (!base) {
+    return res.status(500).json({ error: 'GROUP_SERVICE_URL not configured' })
+  }
+
+  const url = `${base.replace(/\/$/, '')}/xrpc/${nsid}?repo=${encodeURIComponent(repo)}`
+
+  try {
+    const headers: Record<string, string> = { 'X-API-Key': key }
+    if (method === 'POST' && body !== undefined) headers['Content-Type'] = 'application/json'
+
+    const upstream = await fetch(url, {
+      method,
+      headers,
+      body: method === 'POST' && body !== undefined ? JSON.stringify(body) : undefined,
+    })
+
+    const text = await upstream.text()
+    let data: unknown
+    try {
+      data = JSON.parse(text)
+    } catch {
+      data = text
+    }
+
+    // Surface the group service's status + payload to the page so the demo can
+    // show both a success and a scope-denied (403) outcome.
+    res.json({ status: upstream.status, data })
+  } catch (err: any) {
+    res.status(502).json({ error: err?.message || 'API-key call failed' })
+  }
+})
+
+export default router

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -8,6 +8,7 @@ import { Dashboard } from './pages/Dashboard'
 import { Records } from './pages/Records'
 import { Upload } from './pages/Upload'
 import { AuditLog } from './pages/AuditLog'
+import { ApiKeys } from './pages/ApiKeys'
 
 interface AuthUser {
   did: string
@@ -99,6 +100,7 @@ export function App() {
               <Route path="/records" element={user ? <Records /> : <Navigate to="/login" />} />
               <Route path="/upload" element={user ? <Upload /> : <Navigate to="/login" />} />
               <Route path="/audit" element={user ? <AuditLog /> : <Navigate to="/login" />} />
+              <Route path="/keys" element={user ? <ApiKeys /> : <Navigate to="/login" />} />
             </Route>
           </Routes>
         </BrowserRouter>

--- a/demo/src/api.ts
+++ b/demo/src/api.ts
@@ -49,6 +49,59 @@ export const proxyGet = (nsid: string, params: Record<string, string>) => {
   return request(`/proxy/${nsid}?${qs}`)
 }
 
+// --- API keys ---
+// Management (create / list / delete) is owner-authed, so it goes through the
+// normal atproto-proxy BFF route like any other group XRPC method.
+
+export interface CreatedApiKey {
+  keyRef: string
+  key: string // plaintext — returned only once
+  scopes: string[]
+  createdAt: string
+}
+
+export interface ApiKeySummary {
+  keyRef: string
+  name: string
+  scopes: string[]
+  createdBy: string
+  createdAt: string
+  lastUsedAt?: string
+  revokedAt?: string
+}
+
+export const createApiKey = (groupDid: string, name: string, scopes: string[]) =>
+  proxyPost('app.certified.group.keys.create', { groupDid, repo: groupDid, name, scopes }) as Promise<CreatedApiKey>
+
+export const listApiKeys = (groupDid: string, includeRevoked = false) =>
+  proxyGet('app.certified.group.keys.list', {
+    groupDid,
+    repo: groupDid,
+    ...(includeRevoked ? { includeRevoked: 'true' } : {}),
+  }) as Promise<{ keys: ApiKeySummary[]; cursor?: string }>
+
+export const deleteApiKey = (groupDid: string, keyRef: string) =>
+  proxyPost('app.certified.group.keys.delete', { groupDid, repo: groupDid, keyRef }) as Promise<{
+    keyRef: string
+    revokedAt: string
+  }>
+
+// Using a key authenticates via X-API-Key (no owner session / proxy). The BFF
+// makes the direct call so the secret never leaves the server unnecessarily and
+// CORS/cross-origin is avoided. `repo` rides the querystring (required on the
+// key path, even for write procedures).
+export const callWithApiKey = (args: {
+  key: string
+  nsid: string
+  repo: string
+  method?: 'GET' | 'POST'
+  body?: Record<string, any>
+}) =>
+  request<{ status: number; data: any }>('/keys/call', {
+    method: 'POST',
+    body: JSON.stringify(args),
+  })
+
 // Upload blob
 export const uploadBlob = async (groupDid: string, file: File) => {
   const form = new FormData()

--- a/demo/src/components/Layout.tsx
+++ b/demo/src/components/Layout.tsx
@@ -64,6 +64,7 @@ export function Layout() {
         <Link to="/records" style={styles.link}>Records</Link>
         <Link to="/upload" style={styles.link}>Upload</Link>
         <Link to="/audit" style={styles.link}>Audit</Link>
+        <Link to="/keys" style={styles.link}>API Keys</Link>
         <span style={{ flex: 1 }} />
         {user && (
           <>

--- a/demo/src/pages/ApiKeys.tsx
+++ b/demo/src/pages/ApiKeys.tsx
@@ -1,0 +1,304 @@
+import { useEffect, useState } from 'react'
+import { useGroup } from '../App'
+import {
+  createApiKey,
+  listApiKeys,
+  deleteApiKey,
+  type ApiKeySummary,
+  type CreatedApiKey,
+} from '../api'
+
+// The service binds the `aud` for rpc: scopes, so clients pass the friendly
+// `rpc:<method>` form. repo:/blob: scopes carry no aud and are sent as-is.
+const READ_SCOPES = [
+  { value: 'rpc:app.certified.group.member.list', label: 'Read members (member.list)' },
+  { value: 'rpc:app.certified.group.audit.query', label: 'Read audit log (audit.query)' },
+] as const
+
+const REPO_ACTIONS = ['create', 'update', 'delete'] as const
+type RepoAction = (typeof REPO_ACTIONS)[number]
+
+const inputStyle: React.CSSProperties = {
+  padding: '8px 12px',
+  border: '1px solid #ccc',
+  borderRadius: 4,
+  fontSize: 14,
+}
+
+const btnStyle: React.CSSProperties = {
+  padding: '8px 16px',
+  background: '#1a1a2e',
+  color: '#fff',
+  border: 'none',
+  borderRadius: 4,
+  cursor: 'pointer',
+  fontSize: 13,
+}
+
+const dangerBtn: React.CSSProperties = { ...btnStyle, background: '#e74c3c' }
+
+export function ApiKeys() {
+  const { group } = useGroup()
+  const groupDid = group?.did || ''
+
+  const [name, setName] = useState('')
+  const [readScopes, setReadScopes] = useState<string[]>([READ_SCOPES[0].value])
+  const [repoCollection, setRepoCollection] = useState('')
+  const [repoActions, setRepoActions] = useState<RepoAction[]>([])
+  const [blobMime, setBlobMime] = useState('')
+
+  const [minted, setMinted] = useState<CreatedApiKey | null>(null)
+  const [keys, setKeys] = useState<ApiKeySummary[]>([])
+  const [includeRevoked, setIncludeRevoked] = useState(false)
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  // Assemble the scope list from the picker selections.
+  const scopes: string[] = [
+    ...readScopes,
+    ...(repoCollection.trim() && repoActions.length
+      ? repoActions.map((a) => `repo:${repoCollection.trim()}?action=${a}`)
+      : []),
+    ...(blobMime.trim() ? [`blob:${blobMime.trim()}`] : []),
+  ]
+
+  const refresh = async () => {
+    if (!groupDid) return
+    setError('')
+    try {
+      const res = await listApiKeys(groupDid, includeRevoked)
+      setKeys(res.keys)
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }
+
+  useEffect(() => {
+    void refresh()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupDid, includeRevoked])
+
+  const toggle = <T,>(list: T[], v: T, set: (l: T[]) => void) =>
+    set(list.includes(v) ? list.filter((x) => x !== v) : [...list, v])
+
+  const mint = async () => {
+    setError('')
+    setMinted(null)
+    setCopied(false)
+    if (!name.trim()) return setError('Give the key a name.')
+    if (!scopes.length) return setError('Select at least one scope.')
+    setLoading(true)
+    try {
+      const created = await createApiKey(groupDid, name.trim(), scopes)
+      setMinted(created)
+      setName('')
+      await refresh()
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const revoke = async (keyRef: string) => {
+    setError('')
+    try {
+      await deleteApiKey(groupDid, keyRef)
+      await refresh()
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }
+
+  const copyKey = async () => {
+    if (!minted) return
+    await navigator.clipboard.writeText(minted.key)
+    setCopied(true)
+  }
+
+  if (!group) {
+    return <p>Select or register a group first.</p>
+  }
+
+  return (
+    <div style={{ maxWidth: 820 }}>
+      <h2>API keys</h2>
+      <p style={{ color: '#555', fontSize: 14 }}>
+        Mint a long-lived, scope-limited key an external backend can use via the{' '}
+        <code>X-API-Key</code> header — no owner session, no 2-minute JWT refresh. The plaintext is
+        shown <strong>once</strong>.
+      </p>
+
+      {error && <div style={{ color: '#c0392b', margin: '12px 0' }}>{error}</div>}
+
+      {/* Show-once banner */}
+      {minted && (
+        <div
+          style={{
+            border: '2px solid #27ae60',
+            background: '#eafaf1',
+            borderRadius: 6,
+            padding: 16,
+            margin: '16px 0',
+          }}
+        >
+          <strong>Key created — copy it now, it is never shown again.</strong>
+          <div
+            style={{
+              fontFamily: 'monospace',
+              wordBreak: 'break-all',
+              background: '#fff',
+              padding: 10,
+              borderRadius: 4,
+              margin: '8px 0',
+            }}
+          >
+            {minted.key}
+          </div>
+          <button style={btnStyle} onClick={copyKey}>
+            {copied ? 'Copied ✓' : 'Copy key'}
+          </button>
+          <div style={{ fontSize: 13, color: '#555', marginTop: 8 }}>
+            keyRef <code>{minted.keyRef}</code> · scopes: {minted.scopes.join(', ')}
+          </div>
+        </div>
+      )}
+
+      {/* Mint form */}
+      <div style={{ border: '1px solid #ddd', borderRadius: 6, padding: 16, margin: '12px 0' }}>
+        <h3 style={{ marginTop: 0 }}>Mint a key</h3>
+        <label style={{ display: 'block', marginBottom: 12 }}>
+          Name
+          <br />
+          <input
+            style={{ ...inputStyle, width: '100%', marginTop: 4 }}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. analytics backend"
+          />
+        </label>
+
+        <fieldset style={{ border: '1px solid #eee', borderRadius: 4, marginBottom: 12 }}>
+          <legend>Read scopes (rpc:)</legend>
+          {READ_SCOPES.map((s) => (
+            <label key={s.value} style={{ display: 'block', fontSize: 14 }}>
+              <input
+                type="checkbox"
+                checked={readScopes.includes(s.value)}
+                onChange={() => toggle(readScopes, s.value, setReadScopes)}
+              />{' '}
+              {s.label}
+            </label>
+          ))}
+        </fieldset>
+
+        <fieldset style={{ border: '1px solid #eee', borderRadius: 4, marginBottom: 12 }}>
+          <legend>Record write scopes (repo:)</legend>
+          <label style={{ fontSize: 14 }}>
+            Collection{' '}
+            <input
+              style={inputStyle}
+              value={repoCollection}
+              onChange={(e) => setRepoCollection(e.target.value)}
+              placeholder="app.bsky.feed.post"
+            />
+          </label>
+          <div style={{ marginTop: 6 }}>
+            {REPO_ACTIONS.map((a) => (
+              <label key={a} style={{ fontSize: 14, marginRight: 12 }}>
+                <input
+                  type="checkbox"
+                  checked={repoActions.includes(a)}
+                  onChange={() => toggle(repoActions, a, setRepoActions)}
+                />{' '}
+                {a}
+              </label>
+            ))}
+          </div>
+          <small style={{ color: '#777' }}>
+            Own-vs-any follows your role — a member-issued key only touches its own records.
+          </small>
+        </fieldset>
+
+        <fieldset style={{ border: '1px solid #eee', borderRadius: 4, marginBottom: 12 }}>
+          <legend>Blob upload scope (blob:)</legend>
+          <label style={{ fontSize: 14 }}>
+            Accept{' '}
+            <input
+              style={inputStyle}
+              value={blobMime}
+              onChange={(e) => setBlobMime(e.target.value)}
+              placeholder="image/* or */*"
+            />
+          </label>
+        </fieldset>
+
+        <div style={{ fontSize: 13, color: '#555', marginBottom: 12 }}>
+          Will request {scopes.length} scope{scopes.length === 1 ? '' : 's'}:{' '}
+          <code style={{ wordBreak: 'break-all' }}>{scopes.join('  ') || '(none)'}</code>
+        </div>
+
+        <button style={btnStyle} onClick={mint} disabled={loading}>
+          {loading ? 'Minting…' : 'Mint key'}
+        </button>
+      </div>
+
+      {/* Key list */}
+      <div style={{ margin: '16px 0' }}>
+        <h3>
+          Keys{' '}
+          <label style={{ fontSize: 13, fontWeight: 400, marginLeft: 12 }}>
+            <input
+              type="checkbox"
+              checked={includeRevoked}
+              onChange={(e) => setIncludeRevoked(e.target.checked)}
+            />{' '}
+            include revoked
+          </label>
+        </h3>
+        {keys.length === 0 ? (
+          <p style={{ color: '#777' }}>No keys yet.</p>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+            <thead>
+              <tr style={{ textAlign: 'left', borderBottom: '1px solid #ccc' }}>
+                <th>Name</th>
+                <th>keyRef</th>
+                <th>Scopes</th>
+                <th>Created</th>
+                <th>Last used</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map((k) => (
+                <tr
+                  key={k.keyRef}
+                  style={{ borderBottom: '1px solid #eee', opacity: k.revokedAt ? 0.5 : 1 }}
+                >
+                  <td>{k.name}</td>
+                  <td>
+                    <code>{k.keyRef}</code>
+                  </td>
+                  <td style={{ maxWidth: 280, wordBreak: 'break-all' }}>{k.scopes.join(', ')}</td>
+                  <td>{k.createdAt?.slice(0, 10)}</td>
+                  <td>{k.lastUsedAt?.slice(0, 10) ?? '—'}</td>
+                  <td>
+                    {k.revokedAt ? (
+                      <span style={{ color: '#999' }}>revoked</span>
+                    ) : (
+                      <button style={dangerBtn} onClick={() => revoke(k.keyRef)}>
+                        Revoke
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/demo/src/pages/ApiKeys.tsx
+++ b/demo/src/pages/ApiKeys.tsx
@@ -4,6 +4,7 @@ import {
   createApiKey,
   listApiKeys,
   deleteApiKey,
+  callWithApiKey,
   type ApiKeySummary,
   type CreatedApiKey,
 } from '../api'
@@ -54,6 +55,12 @@ export function ApiKeys() {
   const [loading, setLoading] = useState(false)
   const [copied, setCopied] = useState(false)
 
+  // "Use a key" demo state
+  const [tryKey, setTryKey] = useState('')
+  const [tryResult, setTryResult] = useState<{ status: number; data: any } | null>(null)
+  const [tryError, setTryError] = useState('')
+  const [trying, setTrying] = useState(false)
+
   // Assemble the scope list from the picker selections.
   const scopes: string[] = [
     ...readScopes,
@@ -92,6 +99,7 @@ export function ApiKeys() {
     try {
       const created = await createApiKey(groupDid, name.trim(), scopes)
       setMinted(created)
+      setTryKey(created.key) // prefill the "use a key" box with the fresh key
       setName('')
       await refresh()
     } catch (err: any) {
@@ -115,6 +123,28 @@ export function ApiKeys() {
     if (!minted) return
     await navigator.clipboard.writeText(minted.key)
     setCopied(true)
+  }
+
+  // Call member.list with the key — no owner session involved, proving the key
+  // stands on its own. A key without the member.list scope gets a 403 here.
+  const useKeyForMemberList = async () => {
+    setTryError('')
+    setTryResult(null)
+    if (!tryKey.trim()) return setTryError('Paste a key (the cgsk_… value shown at creation).')
+    setTrying(true)
+    try {
+      const res = await callWithApiKey({
+        key: tryKey.trim(),
+        nsid: 'app.certified.group.member.list',
+        repo: groupDid,
+        method: 'GET',
+      })
+      setTryResult(res)
+    } catch (err: any) {
+      setTryError(err.message)
+    } finally {
+      setTrying(false)
+    }
   }
 
   if (!group) {
@@ -242,6 +272,42 @@ export function ApiKeys() {
         <button style={btnStyle} onClick={mint} disabled={loading}>
           {loading ? 'Minting…' : 'Mint key'}
         </button>
+      </div>
+
+      {/* Use a key */}
+      <div style={{ border: '1px solid #ddd', borderRadius: 6, padding: 16, margin: '12px 0' }}>
+        <h3 style={{ marginTop: 0 }}>Use a key</h3>
+        <p style={{ fontSize: 13, color: '#555', marginTop: 0 }}>
+          Calls <code>member.list</code> with the key via the <code>X-API-Key</code> header — no
+          owner session. A key without the <code>member.list</code> scope returns <code>403</code>.
+        </p>
+        <input
+          style={{ ...inputStyle, width: '100%', fontFamily: 'monospace', marginBottom: 8 }}
+          value={tryKey}
+          onChange={(e) => setTryKey(e.target.value)}
+          placeholder="cgsk_…"
+        />
+        <button style={btnStyle} onClick={useKeyForMemberList} disabled={trying}>
+          {trying ? 'Calling…' : 'Call member.list with this key'}
+        </button>
+        {tryError && <div style={{ color: '#c0392b', marginTop: 8 }}>{tryError}</div>}
+        {tryResult && (
+          <div style={{ marginTop: 8 }}>
+            <strong>HTTP {tryResult.status}</strong>
+            <pre
+              style={{
+                background: '#1a1a2e',
+                color: '#9fe',
+                padding: 10,
+                borderRadius: 4,
+                overflowX: 'auto',
+                fontSize: 12,
+              }}
+            >
+              {JSON.stringify(tryResult.data, null, 2)}
+            </pre>
+          </div>
+        )}
       </div>
 
       {/* Key list */}

--- a/demo/src/pages/ApiKeys.tsx
+++ b/demo/src/pages/ApiKeys.tsx
@@ -121,8 +121,18 @@ export function ApiKeys() {
 
   const copyKey = async () => {
     if (!minted) return
-    await navigator.clipboard.writeText(minted.key)
-    setCopied(true)
+    // navigator.clipboard is only available in secure contexts and can reject;
+    // fail gracefully (the key is shown in full above, so the user can select it).
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(minted.key)
+        setCopied(true)
+      } else {
+        setError('Clipboard unavailable — select the key above and copy manually.')
+      }
+    } catch {
+      setError('Could not copy to clipboard — select the key above and copy manually.')
+    }
   }
 
   // Call member.list with the key — no owner session involved, proving the key

--- a/railway-demo.toml
+++ b/railway-demo.toml
@@ -1,0 +1,24 @@
+# Railway config for the DEMO app (demo/) — a separate Railway service from the
+# group service (which uses the root railway.toml). Point a Railway service at
+# this file via its config-as-code path, and set the service Root Directory to
+# `demo` so the Dockerfile build context is the demo app.
+#
+# Required service variables (set in Railway, not committed):
+#   GROUP_SERVICE_URL   e.g. https://dev.groups.certified.app
+#   GROUP_SERVICE_DID   e.g. did:web:dev.groups.certified.app
+#   EPDS_URL            https://epds1.test.certified.app
+#   SESSION_SECRET      a long random string
+#   OAUTH_CLIENT_ID     https://<this-demo-domain>/client-metadata.json
+#   OAUTH_REDIRECT_URI  https://<this-demo-domain>/api/oauth/callback
+# Railway injects PORT; the BFF listens on it and serves both /api and the SPA.
+
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/api/health"
+healthcheckTimeout = 60
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 5
+drainingSeconds = 30


### PR DESCRIPTION
## Summary

Adds API-key support to the demo app and makes it deployable as its own Railway service.

- **API Keys page** (`demo/src/pages/ApiKeys.tsx`, route `/keys`): mint a scope-limited key with a full scope picker — `rpc:` reads (member.list, audit.query), record-write `repo:<collection>?action=…`, and `blob:<accept>` uploads — show the plaintext **once** (copy-to-clipboard, "never shown again"), list active keys (never the secret; `includeRevoked` toggle), and revoke.
- **Use a key** (`demo/server/routes/keys.ts`, `POST /api/keys/call`): a BFF route that calls the group service directly with the `X-API-Key` header (no owner session, no atproto-proxy) and `repo` on the querystring — proving a key works on its own. The page calls `member.list` with the key and shows the status + payload (a key lacking the scope returns `403`).
- Management (`keys.create`/`list`/`delete`) routes through the existing `atproto-proxy` BFF — they're owner-authed XRPC methods.
- **Railway deploy:** `railway-demo.toml` + `demo/Dockerfile` for a single-container service; the BFF now serves the built SPA in production (`express.static` + SPA fallback), listens on `PORT`. Creating the Railway service + setting env is a manual step (documented).
- **`demo/README.md`** — the demo previously had none: purpose, page map, architecture, local dev (`pnpm install --ignore-workspace` caveat — the demo isn't a workspace member), env vars, prod build, and Railway deploy.

Builds on the API-key framework merged in #34.

## Notes

- The demo runs on Railway, not locally end-to-end: OAuth needs a publicly reachable `client-metadata.json`, so full login requires a real domain.
- No automated CI covers `demo/` (no demo test/lint job); verified locally — client + server `tsc` clean, `vite build` clean, prettier clean repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)