### PR TITLE
fix(demo): move railway config into demo/ for Root Directory=demo deploy

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -93,11 +93,12 @@ The demo deploys as its **own** Railway service (separate from the group service
 which uses the repo-root `railway.toml`):
 
 1. Create a new Railway service in the project, pointing at this repo.
-2. Set its **Root Directory** to `demo` and its **config path** to
-   [`railway-demo.toml`](../railway-demo.toml) (at the repo root).
+2. Set its **Root Directory** to `demo`. That's the only build setting needed —
+   Railway then auto-detects [`demo/railway.toml`](./railway.toml) and builds
+   `demo/Dockerfile` (the build context is `demo/`, which is self-contained).
 3. Set the service variables listed under [Environment](#environment-env) — with
    `OAUTH_CLIENT_ID` / `OAUTH_REDIRECT_URI` pointing at the service's Railway
    domain.
 
-Railway builds the `demo/Dockerfile` and injects `PORT`; the BFF serves both the
-API and the SPA. The healthcheck path is `/api/health`.
+Railway injects `PORT`; the BFF serves both the API and the SPA. The healthcheck
+path is `/api/health`.

--- a/demo/railway.toml
+++ b/demo/railway.toml
@@ -1,7 +1,7 @@
-# Railway config for the DEMO app (demo/) — a separate Railway service from the
-# group service (which uses the root railway.toml). Point a Railway service at
-# this file via its config-as-code path, and set the service Root Directory to
-# `demo` so the Dockerfile build context is the demo app.
+# Railway config for the DEMO app — a separate Railway service from the group
+# service (which uses the repo-root railway.toml). Set the service's Root
+# Directory to `demo`; Railway then auto-detects this file (demo/railway.toml)
+# and builds demo/Dockerfile. No config-as-code path needs to be set.
 #
 # Required service variables (set in Railway, not committed):
 #   GROUP_SERVICE_URL   e.g. https://dev.groups.certified.app


### PR DESCRIPTION
## Problem

The demo Railway service (`CGS demo app` in `pr-base`) failed to deploy: the build logs show it ran the **repo-root `Dockerfile`** (the group service — `.cgs-version`, `lexicons/`, `data/groups`) and the container then crashed in the group service's `src/config.ts` Zod validation (`invalid_type … Required`), so the `/api/health` healthcheck never came up.

Root cause — two service misconfigurations, both because the build wasn't pointed at the demo:

1. A **custom-named** `railway-demo.toml` at the repo root is **not auto-detected** by Railway (only `railway.toml`/`railway.json` at the service's root directory are).
2. The service's **Root Directory wasn't `demo`**, so the build context was the repo root → wrong Dockerfile.

## Fix

The demo is fully self-contained within `demo/` (verified: no source import or Dockerfile `COPY` reaches outside it, no `workspace:`/`file:` deps), so the simplest deploy shape is **"Root Directory = demo" as the only build setting**:

- Move `railway-demo.toml` → **`demo/railway.toml`**. With Root Directory = `demo`, Railway auto-detects it and builds `demo/Dockerfile` (`dockerfilePath = "Dockerfile"`, now relative to `demo/`). No config-as-code path needed.
- README deploy steps updated accordingly.

## Manual step (not in this PR)

On the `CGS demo app` service: set **Root Directory = `demo`** and the app env vars (`GROUP_SERVICE_URL`/`DID`, `EPDS_URL`, `SESSION_SECRET`, `OAUTH_CLIENT_ID`/`REDIRECT_URI`). After merge + that setting, the service builds the demo and serves both the API and the SPA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)