### PR TITLE
fix(demo): make the Docker build succeed (deps, allowBuilds, prune TTY)

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -2,15 +2,20 @@
 # The BFF serves both /api and the built client (see server/index.ts).
 FROM node:22-slim AS builder
 WORKDIR /app
+# CI=true so pnpm runs non-interactively (e.g. `prune --prod` won't block on a
+# TTY confirmation for purging modules).
+ENV CI=true
 RUN corepack enable
-# The demo is not a pnpm workspace member, so install with --ignore-workspace
-# (otherwise pnpm treats the repo root workspace as context and skips it).
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile --ignore-workspace
+# In this build the context is demo/ (Railway Root Directory = demo), so there is
+# no parent pnpm workspace — demo/pnpm-workspace.yaml is the workspace root here.
+# Copy it so its `allowBuilds` is read, letting esbuild/core-js build their native
+# pieces without an interactive `pnpm approve-builds` (no --ignore-workspace).
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
 COPY . .
 # vite build -> dist/ (client), tsc -p tsconfig.server.json -> dist-server/ (BFF)
 RUN pnpm build
-RUN pnpm prune --prod --ignore-workspace
+RUN pnpm prune --prod
 
 FROM node:22-slim
 WORKDIR /app

--- a/demo/package.json
+++ b/demo/package.json
@@ -12,8 +12,10 @@
   },
   "dependencies": {
     "@atproto/api": "^0.19.3",
+    "@atproto/lexicon": "^0.6.2",
     "@atproto/oauth-client-node": "^0.3.17",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.0",
     "express": "^4.21.0",
     "express-session": "^1.18.0",
     "multer": "^1.4.5-lts.1"

--- a/demo/pnpm-lock.yaml
+++ b/demo/pnpm-lock.yaml
@@ -11,12 +11,18 @@ importers:
       '@atproto/api':
         specifier: ^0.19.3
         version: 0.19.4
+      '@atproto/lexicon':
+        specifier: ^0.6.2
+        version: 0.6.2
       '@atproto/oauth-client-node':
         specifier: ^0.3.17
         version: 0.3.17
       cors:
         specifier: ^2.8.5
         version: 2.8.6
+      dotenv:
+        specifier: ^16.4.0
+        version: 16.6.1
       express:
         specifier: ^4.21.0
         version: 4.22.1
@@ -592,66 +598,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -897,6 +916,10 @@ packages:
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2210,6 +2233,8 @@ snapshots:
   depd@2.0.0: {}
 
   destroy@1.2.0: {}
+
+  dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/demo/pnpm-workspace.yaml
+++ b/demo/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+# The demo's pnpm workspace root. It declares no sub-packages — it exists only
+# to allow the build scripts pnpm would otherwise skip, so a non-interactive
+# `pnpm install` (e.g. in the Dockerfile) builds esbuild's and core-js's native
+# pieces without an interactive `pnpm approve-builds`. Mirrors the repo-root
+# pnpm-workspace.yaml. Install from demo/ as the workspace root (no
+# --ignore-workspace) so this file is read.
+allowBuilds:
+  esbuild: true
+  core-js: true


### PR DESCRIPTION
## Problem

The demo Railway service's Docker build failed. Diagnosed by reproducing it with a clean local `docker build` of `demo/Dockerfile`, which surfaced three sequential failures.

## Fixes (verified — clean `docker build` now exits 0 and produces the image)

1. **Ignored build scripts.** pnpm v11 skips build scripts (esbuild, core-js) without approval, so the build demanded an interactive `pnpm approve-builds` and `vite build` couldn't run. Added `demo/pnpm-workspace.yaml` with `allowBuilds` (mirroring the repo-root file) and dropped `--ignore-workspace` from the Dockerfile install — in the demo-rooted build context (Railway Root Directory = `demo`) there is no parent workspace, so `demo/` is the workspace root and its `allowBuilds` is honoured non-interactively.
2. **Missing dependencies.** The server imports `dotenv` and `@atproto/lexicon`, which previously resolved only via the parent repo's hoisted `node_modules` (phantom deps). Declared both in `demo/package.json` (and updated the lockfile), so the isolated build resolves them — `tsc -p tsconfig.server.json` now passes.
3. **`pnpm prune --prod` TTY abort.** pnpm v11 refuses to purge modules without a TTY. Set `ENV CI=true` in the builder stage so it runs non-interactively.

## Verification

```
docker build -t cgs-demo-test -f demo/Dockerfile demo/   # exit 0
# … vite build ✓ … tsc server ✓ … core-js postinstall: Done … writing image … done
```

Follows #44 (demo API-key feature) and #45 (move railway config into `demo/`). The Railway service still needs Root Directory = `demo` + its env vars set manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)