### PR TITLE
fix(demo): get API-key flows working end-to-end on the deployed demo

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,10 +1,9 @@
 # Demo app (React SPA + Express BFF) — single-container image.
 # The BFF serves both /api and the built client (see server/index.ts).
 #
-# IMPORTANT: this image is built with the REPO ROOT as the build context (set the
-# Railway service's Root Directory to the repo root, and dockerfilePath to
-# demo/Dockerfile). Root context is required so the demo can copy the repo-root
-# lexicons/ at build time — the custom CGS lexicons are NOT duplicated into demo/.
+# Built with the REPO ROOT as the build context (Railway service Root Directory =
+# repo root, dockerfilePath = demo/Dockerfile). The demo itself lives entirely
+# under demo/; only demo/* is copied.
 FROM node:22-slim AS builder
 WORKDIR /app
 # CI=true so pnpm runs non-interactively (e.g. `prune --prod` won't block on a
@@ -19,10 +18,7 @@ RUN corepack enable
 COPY demo/package.json demo/pnpm-lock.yaml demo/pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
-# App source + the custom lexicons (single source of truth in repo-root lexicons/,
-# copied here at build time — never committed into demo/).
 COPY demo/ ./
-COPY lexicons/ ./lexicons
 
 # vite build -> dist/ (client), tsc -p tsconfig.server.json -> dist-server/ (BFF)
 RUN pnpm build
@@ -31,14 +27,10 @@ RUN pnpm prune --prod
 FROM node:22-slim
 WORKDIR /app
 ENV NODE_ENV=production
-# Tell the proxy agent exactly where the lexicons are, rather than relying on a
-# relative ../../../ walk from the compiled file.
-ENV LEXICONS_DIR=/app/lexicons/app/certified
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/dist-server ./dist-server
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
-COPY --from=builder /app/lexicons ./lexicons
 # The server listens on PORT (Railway's convention) then BFF_PORT then 3001.
 EXPOSE 3001
 CMD ["node", "dist-server/index.js"]

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,18 +1,29 @@
 # Demo app (React SPA + Express BFF) — single-container image.
 # The BFF serves both /api and the built client (see server/index.ts).
+#
+# IMPORTANT: this image is built with the REPO ROOT as the build context (set the
+# Railway service's Root Directory to the repo root, and dockerfilePath to
+# demo/Dockerfile). Root context is required so the demo can copy the repo-root
+# lexicons/ at build time — the custom CGS lexicons are NOT duplicated into demo/.
 FROM node:22-slim AS builder
 WORKDIR /app
 # CI=true so pnpm runs non-interactively (e.g. `prune --prod` won't block on a
 # TTY confirmation for purging modules).
 ENV CI=true
 RUN corepack enable
-# In this build the context is demo/ (Railway Root Directory = demo), so there is
-# no parent pnpm workspace — demo/pnpm-workspace.yaml is the workspace root here.
-# Copy it so its `allowBuilds` is read, letting esbuild/core-js build their native
-# pieces without an interactive `pnpm approve-builds` (no --ignore-workspace).
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+# Install the demo's deps from demo/ as its own pnpm workspace root (demo has its
+# own pnpm-workspace.yaml carrying `allowBuilds`, so esbuild/core-js build their
+# native pieces without an interactive `pnpm approve-builds`). Paths are relative
+# to the repo root (the build context).
+COPY demo/package.json demo/pnpm-lock.yaml demo/pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
-COPY . .
+
+# App source + the custom lexicons (single source of truth in repo-root lexicons/,
+# copied here at build time — never committed into demo/).
+COPY demo/ ./
+COPY lexicons/ ./lexicons
+
 # vite build -> dist/ (client), tsc -p tsconfig.server.json -> dist-server/ (BFF)
 RUN pnpm build
 RUN pnpm prune --prod
@@ -20,10 +31,14 @@ RUN pnpm prune --prod
 FROM node:22-slim
 WORKDIR /app
 ENV NODE_ENV=production
+# Tell the proxy agent exactly where the lexicons are, rather than relying on a
+# relative ../../../ walk from the compiled file.
+ENV LEXICONS_DIR=/app/lexicons/app/certified
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/dist-server ./dist-server
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
+COPY --from=builder /app/lexicons ./lexicons
 # The server listens on PORT (Railway's convention) then BFF_PORT then 3001.
 EXPOSE 3001
 CMD ["node", "dist-server/index.js"]

--- a/demo/README.md
+++ b/demo/README.md
@@ -93,9 +93,13 @@ The demo deploys as its **own** Railway service (separate from the group service
 which uses the repo-root `railway.toml`):
 
 1. Create a new Railway service in the project, pointing at this repo.
-2. Set its **Root Directory** to `demo`. That's the only build setting needed —
-   Railway then auto-detects [`demo/railway.toml`](./railway.toml) and builds
-   `demo/Dockerfile` (the build context is `demo/`, which is self-contained).
+2. Build settings — the demo builds with the **repo root** as context (so it can
+   copy the repo-root `lexicons/` at build time; the custom lexicons are never
+   duplicated into `demo/`):
+   - **Root Directory:** the repo root (default / unset).
+   - **Config-as-code path:** [`railway-demo.toml`](../railway-demo.toml) — set
+     this explicitly, since the repo root already has `railway.toml` for the
+     group service. It builds `demo/Dockerfile`.
 3. Set the service variables listed under [Environment](#environment-env) — with
    `OAUTH_CLIENT_ID` / `OAUTH_REDIRECT_URI` pointing at the service's Railway
    domain.

--- a/demo/README.md
+++ b/demo/README.md
@@ -93,9 +93,9 @@ The demo deploys as its **own** Railway service (separate from the group service
 which uses the repo-root `railway.toml`):
 
 1. Create a new Railway service in the project, pointing at this repo.
-2. Build settings — the demo builds with the **repo root** as context (so it can
-   copy the repo-root `lexicons/` at build time; the custom lexicons are never
-   duplicated into `demo/`):
+2. Build settings — the demo builds with the **repo root** as context (the
+   service's Root Directory is the repo root, and `demo/Dockerfile` copies only
+   `demo/*`):
    - **Root Directory:** the repo root (default / unset).
    - **Config-as-code path:** [`railway-demo.toml`](../railway-demo.toml) — set
      this explicitly, since the repo root already has `railway.toml` for the

--- a/demo/server/index.ts
+++ b/demo/server/index.ts
@@ -7,6 +7,7 @@ import cors from 'cors'
 import authRoutes from './routes/auth.js'
 import proxyRoutes from './routes/proxy.js'
 import uploadRoutes from './routes/upload.js'
+import resolveRoutes from './routes/resolve.js'
 import registerRoutes from './routes/register.js'
 import keysRoutes from './routes/keys.js'
 
@@ -65,6 +66,7 @@ app.use('/api', authRoutes)
 app.use('/api/proxy', proxyRoutes)
 app.use('/api/register', registerRoutes)
 app.use('/api/keys', keysRoutes)
+app.use('/api/resolve', resolveRoutes)
 
 // Health check
 app.get('/api/health', (_req, res) => res.json({ ok: true }))

--- a/demo/server/index.ts
+++ b/demo/server/index.ts
@@ -19,11 +19,9 @@ if (!sessionSecret) throw new Error('SESSION_SECRET must be set')
 
 app.use(cors({ origin: true, credentials: true }))
 
-// Mount upload route before express.json() to preserve raw stream access
-app.use('/api/upload-blob', uploadRoutes)
-
-app.use(express.json())
-
+// Session must come before any route that reads req.session — including the
+// raw upload route below, which authenticates the caller. Session does not
+// consume the request body, so mounting it before express.json() is fine.
 app.use(
   session({
     secret: sessionSecret,
@@ -36,6 +34,11 @@ app.use(
     },
   }),
 )
+
+// Mount upload route before express.json() to preserve raw stream access
+app.use('/api/upload-blob', uploadRoutes)
+
+app.use(express.json())
 
 // Serve OAuth client metadata (ePDS fetches this to verify the client)
 app.get('/client-metadata.json', (_req, res) => {

--- a/demo/server/oauth/client.ts
+++ b/demo/server/oauth/client.ts
@@ -1,37 +1,67 @@
 import { NodeOAuthClient } from '@atproto/oauth-client-node'
 import type { NodeSavedSessionStore, NodeSavedStateStore } from '@atproto/oauth-client-node'
 
-const CLIENT_ID = process.env.OAUTH_CLIENT_ID || ''
-const REDIRECT_URI = process.env.OAUTH_REDIRECT_URI || ''
-
 // In-memory stores — fine for a demo, swap for Redis/DB in production
-const stateStore: NodeSavedStateStore = {
-  async get(key) { return states.get(key) },
-  async set(key, val) { states.set(key, val) },
-  async del(key) { states.delete(key) },
-}
 const states = new Map<string, any>()
-
-const sessionStore: NodeSavedSessionStore = {
-  async get(key) { return sessions.get(key) },
-  async set(key, val) { sessions.set(key, val) },
-  async del(key) { sessions.delete(key) },
-}
-const sessions = new Map<string, any>()
-
-export const oauthClient = new NodeOAuthClient({
-  clientMetadata: {
-    client_id: CLIENT_ID,
-    client_name: 'Group Service Demo',
-    client_uri: CLIENT_ID.replace('/client-metadata.json', ''),
-    redirect_uris: [REDIRECT_URI as `https://${string}`],
-    scope: 'atproto transition:generic',
-    grant_types: ['authorization_code', 'refresh_token'],
-    response_types: ['code'],
-    token_endpoint_auth_method: 'none',
-    dpop_bound_access_tokens: true,
+const stateStore: NodeSavedStateStore = {
+  async get(key) {
+    return states.get(key)
   },
-  stateStore,
-  sessionStore,
-  allowHttp: true,
-})
+  async set(key, val) {
+    states.set(key, val)
+  },
+  async del(key) {
+    states.delete(key)
+  },
+}
+
+const sessions = new Map<string, any>()
+const sessionStore: NodeSavedSessionStore = {
+  async get(key) {
+    return sessions.get(key)
+  },
+  async set(key, val) {
+    sessions.set(key, val)
+  },
+  async del(key) {
+    sessions.delete(key)
+  },
+}
+
+// Construct lazily: NodeOAuthClient validates client_id/redirect_uri at build
+// time (it throws `Invalid URL` on an empty client_id), so building it at module
+// load would crash the whole BFF — and the /api/health endpoint with it — when
+// OAUTH_CLIENT_ID / OAUTH_REDIRECT_URI aren't set. Deferring construction keeps
+// the server bootable; only the OAuth routes fail (with a clear error) until the
+// env is configured.
+let client: NodeOAuthClient | undefined
+
+export function getOauthClient(): NodeOAuthClient {
+  if (client) return client
+
+  const clientId = process.env.OAUTH_CLIENT_ID
+  const redirectUri = process.env.OAUTH_REDIRECT_URI
+  if (!clientId || !redirectUri) {
+    throw new Error(
+      'OAuth is not configured: set OAUTH_CLIENT_ID and OAUTH_REDIRECT_URI (see demo/README.md).',
+    )
+  }
+
+  client = new NodeOAuthClient({
+    clientMetadata: {
+      client_id: clientId,
+      client_name: 'Group Service Demo',
+      client_uri: clientId.replace('/client-metadata.json', ''),
+      redirect_uris: [redirectUri as `https://${string}`],
+      scope: 'atproto transition:generic',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      dpop_bound_access_tokens: true,
+    },
+    stateStore,
+    sessionStore,
+    allowHttp: true,
+  })
+  return client
+}

--- a/demo/server/oauth/proxy-agent.ts
+++ b/demo/server/oauth/proxy-agent.ts
@@ -19,6 +19,18 @@ export interface GroupServiceResult {
 }
 
 /**
+ * The service DID is the JWT audience for every direct group-service call. Fail
+ * fast with a clear message if it is unset, rather than letting getServiceAuth
+ * reject with an opaque "empty aud" error deep in the call.
+ */
+function requireServiceDid(): string {
+  if (!GROUP_SERVICE_DID) {
+    throw new Error('GROUP_SERVICE_DID is not configured (see demo/README.md)')
+  }
+  return GROUP_SERVICE_DID
+}
+
+/**
  * Call a group-service XRPC method directly, authenticated with a service-auth
  * JWT minted by the user's PDS (aud = the group service DID, lxm = the method).
  *
@@ -36,19 +48,18 @@ export async function callGroupService(
   nsid: string,
   opts: { method: 'GET' | 'POST'; params?: Record<string, string>; body?: Record<string, unknown> },
 ): Promise<GroupServiceResult> {
+  const aud = requireServiceDid()
   const oauthSession = await getOauthClient().restore(userDid)
   const agent = new Agent(oauthSession)
 
   // Prove the caller controls userDid; aud = service DID, lxm = the method.
-  const serviceAuth = await agent.com.atproto.server.getServiceAuth({
-    aud: GROUP_SERVICE_DID,
-    lxm: nsid,
-  })
+  const serviceAuth = await agent.com.atproto.server.getServiceAuth({ aud, lxm: nsid })
 
   // The group is always identified by `repo`: querystring for queries, body for
   // procedures (matches the group service's verifier, which reads repo before
-  // the body is parsed for queries).
-  const query = new URLSearchParams({ repo: groupDid, ...(opts.params ?? {}) }).toString()
+  // the body is parsed for queries). Force repo = groupDid LAST so a caller's
+  // params/body can never override the routing target.
+  const query = new URLSearchParams({ ...(opts.params ?? {}), repo: groupDid }).toString()
   const url = `${GROUP_SERVICE_URL.replace(/\/$/, '')}/xrpc/${nsid}?${query}`
 
   const headers: Record<string, string> = { Authorization: `Bearer ${serviceAuth.data.token}` }
@@ -57,7 +68,8 @@ export async function callGroupService(
     headers['Content-Type'] = 'application/json'
     // Include repo in the body too so procedure handlers that read input.body.repo
     // resolve the same group (the confused-deputy guard requires body == querystring).
-    requestBody = JSON.stringify({ repo: groupDid, ...(opts.body ?? {}) })
+    // repo is forced last so a caller-supplied repo cannot override groupDid.
+    requestBody = JSON.stringify({ ...(opts.body ?? {}), repo: groupDid })
   }
 
   const upstream = await fetch(url, { method: opts.method, headers, body: requestBody })
@@ -76,13 +88,11 @@ export async function uploadGroupBlob(
   bytes: Uint8Array,
   mimetype: string,
 ): Promise<GroupServiceResult> {
+  const aud = requireServiceDid()
   const oauthSession = await getOauthClient().restore(userDid)
   const agent = new Agent(oauthSession)
   const nsid = 'app.certified.group.repo.uploadBlob'
-  const serviceAuth = await agent.com.atproto.server.getServiceAuth({
-    aud: GROUP_SERVICE_DID,
-    lxm: nsid,
-  })
+  const serviceAuth = await agent.com.atproto.server.getServiceAuth({ aud, lxm: nsid })
   const url = `${GROUP_SERVICE_URL.replace(/\/$/, '')}/xrpc/${nsid}?repo=${encodeURIComponent(groupDid)}`
   const upstream = await fetch(url, {
     method: 'POST',

--- a/demo/server/oauth/proxy-agent.ts
+++ b/demo/server/oauth/proxy-agent.ts
@@ -3,7 +3,7 @@ import { join, extname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Agent } from '@atproto/api'
 import type { LexiconDoc } from '@atproto/lexicon'
-import { oauthClient } from './client.js'
+import { getOauthClient } from './client.js'
 
 /** Recursively load all .json lexicon files from a directory. */
 function loadLexicons(dir: string): LexiconDoc[] {
@@ -20,9 +20,26 @@ function loadLexicons(dir: string): LexiconDoc[] {
 }
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
-const customLexicons = loadLexicons(
-  join(__dirname, '..', '..', '..', 'lexicons', 'app', 'certified'),
-)
+
+// The custom CGS lexicons (app.certified.group.repo.*) registered on the proxy
+// agent so the @atproto/api client recognises them. They live in the repo-root
+// lexicons/; in the deployed image that resolves to /app/lexicons/app/certified.
+// Override with LEXICONS_DIR if your layout differs. Fail soft: a missing dir
+// logs a clear warning and leaves customLexicons empty (the server still boots
+// and /api/health responds) rather than crashing the whole BFF at module load.
+const lexiconsDir =
+  process.env.LEXICONS_DIR || join(__dirname, '..', '..', '..', 'lexicons', 'app', 'certified')
+
+let customLexicons: LexiconDoc[] = []
+try {
+  customLexicons = loadLexicons(lexiconsDir)
+} catch (err) {
+  console.error(
+    `[proxy-agent] could not load custom lexicons from ${lexiconsDir} — ` +
+      `record/proxy operations needing them will fail. Set LEXICONS_DIR to the ` +
+      `directory containing app/certified/*.json. Cause: ${(err as Error).message}`,
+  )
+}
 
 export function isSessionExpiredError(err: any): boolean {
   // Only treat OAuth-layer failures as session-expired.
@@ -38,7 +55,7 @@ export function isSessionExpiredError(err: any): boolean {
  * proxied through the certified_group service to the given group DID.
  */
 export async function createProxyAgent(userDid: string, groupDid: string): Promise<Agent> {
-  const oauthSession = await oauthClient.restore(userDid)
+  const oauthSession = await getOauthClient().restore(userDid)
   const agent = new Agent(oauthSession)
   const proxied = agent.withProxy('certified_group', groupDid) as Agent
   for (const doc of customLexicons) {

--- a/demo/server/oauth/proxy-agent.ts
+++ b/demo/server/oauth/proxy-agent.ts
@@ -12,10 +12,33 @@ export function isSessionExpiredError(err: any): boolean {
 
 const GROUP_SERVICE_URL = process.env.GROUP_SERVICE_URL || 'http://localhost:3000'
 const GROUP_SERVICE_DID = process.env.GROUP_SERVICE_DID || ''
+const UPSTREAM_TIMEOUT_MS = 15_000
 
 export interface GroupServiceResult {
   status: number
   data: any
+}
+
+/**
+ * fetch() bounded by a timeout so a slow/wedged group service can't hold a
+ * request handler open indefinitely. A timeout surfaces as a 504; other
+ * transport failures as 502.
+ */
+async function fetchUpstream(url: string, init: RequestInit): Promise<GroupServiceResult> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS)
+  try {
+    const upstream = await fetch(url, { ...init, signal: controller.signal })
+    const data = await upstream.json().catch(() => ({}))
+    return { status: upstream.status, data }
+  } catch (err: any) {
+    if (err?.name === 'AbortError') {
+      return { status: 504, data: { error: 'group service did not respond in time' } }
+    }
+    return { status: 502, data: { error: err?.message || 'group service request failed' } }
+  } finally {
+    clearTimeout(timer)
+  }
 }
 
 /**
@@ -72,9 +95,7 @@ export async function callGroupService(
     requestBody = JSON.stringify({ ...(opts.body ?? {}), repo: groupDid })
   }
 
-  const upstream = await fetch(url, { method: opts.method, headers, body: requestBody })
-  const data = await upstream.json().catch(() => ({}))
-  return { status: upstream.status, data }
+  return fetchUpstream(url, { method: opts.method, headers, body: requestBody })
 }
 
 /**
@@ -94,7 +115,7 @@ export async function uploadGroupBlob(
   const nsid = 'app.certified.group.repo.uploadBlob'
   const serviceAuth = await agent.com.atproto.server.getServiceAuth({ aud, lxm: nsid })
   const url = `${GROUP_SERVICE_URL.replace(/\/$/, '')}/xrpc/${nsid}?repo=${encodeURIComponent(groupDid)}`
-  const upstream = await fetch(url, {
+  return fetchUpstream(url, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${serviceAuth.data.token}`,
@@ -102,6 +123,4 @@ export async function uploadGroupBlob(
     },
     body: bytes as unknown as BodyInit,
   })
-  const data = await upstream.json().catch(() => ({}))
-  return { status: upstream.status, data }
 }

--- a/demo/server/oauth/proxy-agent.ts
+++ b/demo/server/oauth/proxy-agent.ts
@@ -1,45 +1,5 @@
-import { readFileSync, readdirSync } from 'node:fs'
-import { join, extname } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { Agent } from '@atproto/api'
-import type { LexiconDoc } from '@atproto/lexicon'
 import { getOauthClient } from './client.js'
-
-/** Recursively load all .json lexicon files from a directory. */
-function loadLexicons(dir: string): LexiconDoc[] {
-  const docs: LexiconDoc[] = []
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const fullPath = join(dir, entry.name)
-    if (entry.isDirectory()) {
-      docs.push(...loadLexicons(fullPath))
-    } else if (extname(entry.name) === '.json') {
-      docs.push(JSON.parse(readFileSync(fullPath, 'utf8')))
-    }
-  }
-  return docs
-}
-
-const __dirname = fileURLToPath(new URL('.', import.meta.url))
-
-// The custom CGS lexicons (app.certified.group.repo.*) registered on the proxy
-// agent so the @atproto/api client recognises them. They live in the repo-root
-// lexicons/; in the deployed image that resolves to /app/lexicons/app/certified.
-// Override with LEXICONS_DIR if your layout differs. Fail soft: a missing dir
-// logs a clear warning and leaves customLexicons empty (the server still boots
-// and /api/health responds) rather than crashing the whole BFF at module load.
-const lexiconsDir =
-  process.env.LEXICONS_DIR || join(__dirname, '..', '..', '..', 'lexicons', 'app', 'certified')
-
-let customLexicons: LexiconDoc[] = []
-try {
-  customLexicons = loadLexicons(lexiconsDir)
-} catch (err) {
-  console.error(
-    `[proxy-agent] could not load custom lexicons from ${lexiconsDir} — ` +
-      `record/proxy operations needing them will fail. Set LEXICONS_DIR to the ` +
-      `directory containing app/certified/*.json. Cause: ${(err as Error).message}`,
-  )
-}
 
 export function isSessionExpiredError(err: any): boolean {
   // Only treat OAuth-layer failures as session-expired.
@@ -50,16 +10,88 @@ export function isSessionExpiredError(err: any): boolean {
   return false
 }
 
+const GROUP_SERVICE_URL = process.env.GROUP_SERVICE_URL || 'http://localhost:3000'
+const GROUP_SERVICE_DID = process.env.GROUP_SERVICE_DID || ''
+
+export interface GroupServiceResult {
+  status: number
+  data: any
+}
+
 /**
- * Creates an AtpAgent for the user's PDS (via OAuth session),
- * proxied through the certified_group service to the given group DID.
+ * Call a group-service XRPC method directly, authenticated with a service-auth
+ * JWT minted by the user's PDS (aud = the group service DID, lxm = the method).
+ *
+ * This is preferred over the atproto service-proxy path (`createProxyAgent` +
+ * withProxy): proxying makes the user's PDS resolve the GROUP DID's
+ * `#certified_group` service, which fails ("could not resolve proxy did service
+ * url") whenever the PDS's cached DID document predates the group's
+ * service-entry PLC op. A direct call resolves the group from the `repo`
+ * param (querystring for queries, body for procedures) and never touches PDS
+ * DID-document caching.
  */
-export async function createProxyAgent(userDid: string, groupDid: string): Promise<Agent> {
+export async function callGroupService(
+  userDid: string,
+  groupDid: string,
+  nsid: string,
+  opts: { method: 'GET' | 'POST'; params?: Record<string, string>; body?: Record<string, unknown> },
+): Promise<GroupServiceResult> {
   const oauthSession = await getOauthClient().restore(userDid)
   const agent = new Agent(oauthSession)
-  const proxied = agent.withProxy('certified_group', groupDid) as Agent
-  for (const doc of customLexicons) {
-    proxied.lex.add(doc)
+
+  // Prove the caller controls userDid; aud = service DID, lxm = the method.
+  const serviceAuth = await agent.com.atproto.server.getServiceAuth({
+    aud: GROUP_SERVICE_DID,
+    lxm: nsid,
+  })
+
+  // The group is always identified by `repo`: querystring for queries, body for
+  // procedures (matches the group service's verifier, which reads repo before
+  // the body is parsed for queries).
+  const query = new URLSearchParams({ repo: groupDid, ...(opts.params ?? {}) }).toString()
+  const url = `${GROUP_SERVICE_URL.replace(/\/$/, '')}/xrpc/${nsid}?${query}`
+
+  const headers: Record<string, string> = { Authorization: `Bearer ${serviceAuth.data.token}` }
+  let requestBody: string | undefined
+  if (opts.method === 'POST') {
+    headers['Content-Type'] = 'application/json'
+    // Include repo in the body too so procedure handlers that read input.body.repo
+    // resolve the same group (the confused-deputy guard requires body == querystring).
+    requestBody = JSON.stringify({ repo: groupDid, ...(opts.body ?? {}) })
   }
-  return proxied
+
+  const upstream = await fetch(url, { method: opts.method, headers, body: requestBody })
+  const data = await upstream.json().catch(() => ({}))
+  return { status: upstream.status, data }
+}
+
+/**
+ * Upload a blob to the group service directly (service-auth JWT, raw bytes).
+ * Same rationale as callGroupService — avoids the PDS service-proxy DID
+ * resolution. uploadBlob takes the raw body with the file's content-type.
+ */
+export async function uploadGroupBlob(
+  userDid: string,
+  groupDid: string,
+  bytes: Uint8Array,
+  mimetype: string,
+): Promise<GroupServiceResult> {
+  const oauthSession = await getOauthClient().restore(userDid)
+  const agent = new Agent(oauthSession)
+  const nsid = 'app.certified.group.repo.uploadBlob'
+  const serviceAuth = await agent.com.atproto.server.getServiceAuth({
+    aud: GROUP_SERVICE_DID,
+    lxm: nsid,
+  })
+  const url = `${GROUP_SERVICE_URL.replace(/\/$/, '')}/xrpc/${nsid}?repo=${encodeURIComponent(groupDid)}`
+  const upstream = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${serviceAuth.data.token}`,
+      'Content-Type': mimetype,
+    },
+    body: bytes as unknown as BodyInit,
+  })
+  const data = await upstream.json().catch(() => ({}))
+  return { status: upstream.status, data }
 }

--- a/demo/server/routes/auth.ts
+++ b/demo/server/routes/auth.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 import { Agent } from '@atproto/api'
-import { oauthClient } from '../oauth/client.js'
+import { getOauthClient } from '../oauth/client.js'
 
 const router = Router()
 
@@ -15,7 +15,7 @@ router.post('/login', async (req, res) => {
   try {
     // Accept a handle/DID, or fall back to the ePDS URL for email-based auth
     const input = req.body.handle || EPDS_URL
-    const url = await oauthClient.authorize(input, {
+    const url = await getOauthClient().authorize(input, {
       scope: 'atproto transition:generic',
     })
     res.json({ redirectUrl: url.toString() })
@@ -32,7 +32,7 @@ router.post('/login', async (req, res) => {
 router.get('/oauth/callback', async (req, res) => {
   try {
     const params = new URLSearchParams(req.url.split('?')[1])
-    const { session: oauthSession } = await oauthClient.callback(params)
+    const { session: oauthSession } = await getOauthClient().callback(params)
 
     // Resolve handle
     let handle: string = oauthSession.did

--- a/demo/server/routes/proxy.ts
+++ b/demo/server/routes/proxy.ts
@@ -1,20 +1,24 @@
 import type { Response } from 'express'
 import { Router } from 'express'
-import { createProxyAgent, isSessionExpiredError } from '../oauth/proxy-agent.js'
+import { callGroupService, isSessionExpiredError } from '../oauth/proxy-agent.js'
 
 const router = Router()
 
 function handleProxyError(res: Response, err: any) {
   if (isSessionExpiredError(err)) {
-    return res.status(401).json({ error: 'Session expired — please log in again', sessionExpired: true })
+    return res
+      .status(401)
+      .json({ error: 'Session expired — please log in again', sessionExpired: true })
   }
   const httpStatus = err.status >= 100 ? err.status : 502
   res.status(httpStatus).json({ error: err.message || 'Proxy request failed' })
 }
 
 /**
- * POST /api/proxy/:nsid — proxy a JSON POST to the group service via atproto-proxy
- * Body must include `groupDid` which is used to route the proxy.
+ * POST /api/proxy/:nsid — call a group-service procedure.
+ * Body must include `groupDid` (the target group); the rest is the XRPC input.
+ * Authenticated with a service-auth JWT (see callGroupService) rather than the
+ * atproto service-proxy, which depends on fresh PDS DID-document caching.
  */
 router.post('/:nsid', async (req, res) => {
   try {
@@ -29,17 +33,19 @@ router.post('/:nsid', async (req, res) => {
       return res.status(400).json({ error: 'Missing groupDid' })
     }
 
-    const agent = await createProxyAgent(req.session.user.did, groupDid)
-    const response = await agent.call(nsid, {}, body, { encoding: 'application/json' })
-    res.json(response.data)
+    const { status, data } = await callGroupService(req.session.user.did, groupDid, nsid, {
+      method: 'POST',
+      body,
+    })
+    res.status(status).json(data)
   } catch (err: any) {
     handleProxyError(res, err)
   }
 })
 
 /**
- * GET /api/proxy/:nsid — proxy a query to the group service via atproto-proxy
- * Query param `groupDid` is used to route the proxy.
+ * GET /api/proxy/:nsid — call a group-service query.
+ * Query param `groupDid` is the target group; the rest are XRPC params.
  */
 router.get('/:nsid', async (req, res) => {
   try {
@@ -54,9 +60,11 @@ router.get('/:nsid', async (req, res) => {
       return res.status(400).json({ error: 'Missing groupDid query param' })
     }
 
-    const agent = await createProxyAgent(req.session.user.did, groupDid)
-    const response = await agent.call(nsid, params)
-    res.json(response.data)
+    const { status, data } = await callGroupService(req.session.user.did, groupDid, nsid, {
+      method: 'GET',
+      params,
+    })
+    res.status(status).json(data)
   } catch (err: any) {
     handleProxyError(res, err)
   }

--- a/demo/server/routes/register.ts
+++ b/demo/server/routes/register.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 import { Agent } from '@atproto/api'
-import { oauthClient } from '../oauth/client.js'
+import { getOauthClient } from '../oauth/client.js'
 
 const router = Router()
 const GROUP_SERVICE_URL = process.env.GROUP_SERVICE_URL || 'http://localhost:3000'
@@ -26,7 +26,7 @@ router.post('/', async (req, res) => {
     const ownerDid = req.session.user.did
 
     // Restore the OAuth session to get an authenticated agent
-    const oauthSession = await oauthClient.restore(ownerDid)
+    const oauthSession = await getOauthClient().restore(ownerDid)
     const agent = new Agent(oauthSession)
 
     // Fetch the user's email from their PDS session (optional)

--- a/demo/server/routes/resolve.ts
+++ b/demo/server/routes/resolve.ts
@@ -1,0 +1,42 @@
+import { Router } from 'express'
+
+const router = Router()
+const EPDS_URL = process.env.EPDS_URL || 'https://epds1.test.certified.app'
+
+/**
+ * GET /api/resolve?identifier=<did-or-handle>
+ *
+ * Resolve an at-identifier to a DID so fields can accept either form. A value
+ * that already looks like a DID is returned unchanged; a handle is resolved via
+ * com.atproto.identity.resolveHandle on the ePDS. Done server-side to avoid
+ * cross-origin calls from the browser.
+ */
+router.get('/', async (req, res) => {
+  const identifier = (req.query.identifier as string | undefined)?.trim()
+  if (!identifier) {
+    return res.status(400).json({ error: 'Missing identifier' })
+  }
+
+  // Already a DID — nothing to resolve.
+  if (identifier.startsWith('did:')) {
+    return res.json({ did: identifier, handle: null })
+  }
+
+  // Treat anything else as a handle (strip a leading @ for convenience).
+  const handle = identifier.replace(/^@/, '')
+  try {
+    const url = `${EPDS_URL.replace(/\/$/, '')}/xrpc/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(handle)}`
+    const upstream = await fetch(url)
+    const data = await upstream.json().catch(() => ({}) as any)
+    if (!upstream.ok || !data?.did) {
+      return res.status(upstream.ok ? 404 : upstream.status).json({
+        error: `Could not resolve handle "${handle}"`,
+      })
+    }
+    res.json({ did: data.did, handle })
+  } catch (err: any) {
+    res.status(502).json({ error: err?.message || 'Handle resolution failed' })
+  }
+})
+
+export default router

--- a/demo/server/routes/upload.ts
+++ b/demo/server/routes/upload.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 import multer from 'multer'
-import { createProxyAgent, isSessionExpiredError } from '../oauth/proxy-agent.js'
+import { uploadGroupBlob, isSessionExpiredError } from '../oauth/proxy-agent.js'
 
 const router = Router()
 const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 5 * 1024 * 1024 } })
@@ -24,14 +24,13 @@ router.post('/', upload.single('file'), async (req, res) => {
       return res.status(400).json({ error: 'No file uploaded' })
     }
 
-    const agent = await createProxyAgent(req.session.user.did, groupDid)
-    const response = await agent.call(
-      'app.certified.group.repo.uploadBlob',
-      {},
+    const { status, data } = await uploadGroupBlob(
+      req.session.user.did,
+      groupDid,
       new Uint8Array(req.file.buffer),
-      { encoding: req.file.mimetype },
+      req.file.mimetype,
     )
-    res.json(response.data)
+    res.status(status).json(data)
   } catch (err: any) {
     console.error('Upload error:', err.message)
     if (isSessionExpiredError(err)) {

--- a/demo/src/api.ts
+++ b/demo/src/api.ts
@@ -48,6 +48,15 @@ export const logout = () =>
 export const getMe = () =>
   request<{ did: string; handle: string }>('/me')
 
+/**
+ * Resolve a DID-or-handle to a DID, so fields can accept either. A value that
+ * already looks like a DID is returned as-is; a handle is resolved server-side.
+ */
+export const resolveIdentifier = (identifier: string) =>
+  request<{ did: string; handle: string | null }>(
+    `/resolve?identifier=${encodeURIComponent(identifier.trim())}`,
+  )
+
 // Register (requires auth — owner DID comes from session, service auth proves DID control)
 export const registerGroup = (body: { handle: string }) =>
   request<{ groupDid: string; handle: string }>('/register', { method: 'POST', body: JSON.stringify(body) })

--- a/demo/src/api.ts
+++ b/demo/src/api.ts
@@ -7,6 +7,19 @@ export function setOnUnauthorized(fn: () => void) {
   onUnauthorized = fn
 }
 
+/**
+ * Build a useful error string from an XRPC/BFF error body. Prefer the
+ * human-readable `message` (e.g. "No invite code provided"), and append the
+ * terse error name (e.g. "InvalidRequest") as context when both are present —
+ * otherwise the UI would show only the opaque name and hide the real cause.
+ */
+function formatApiError(data: any, status: number, fallback: string): string {
+  const message = typeof data?.message === 'string' ? data.message : ''
+  const error = typeof data?.error === 'string' ? data.error : ''
+  if (message && error && message !== error) return `${message} (${error})`
+  return message || error || `${fallback} (${status})`
+}
+
 async function request<T = any>(path: string, opts?: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
     credentials: 'include',
@@ -20,7 +33,7 @@ async function request<T = any>(path: string, opts?: RequestInit): Promise<T> {
     if (res.status === 401 && path !== '/me' && data.sessionExpired) {
       onUnauthorized?.()
     }
-    throw new Error(data.error || data.message || `Request failed (${res.status})`)
+    throw new Error(formatApiError(data, res.status, 'Request failed'))
   }
   return data as T
 }
@@ -114,7 +127,7 @@ export const uploadBlob = async (groupDid: string, file: File) => {
   const data = await res.json().catch(() => ({}))
   if (!res.ok) {
     if (res.status === 401 && data.sessionExpired) onUnauthorized?.()
-    throw new Error(data.error || data.message || `Upload failed (${res.status})`)
+    throw new Error(formatApiError(data, res.status, 'Upload failed'))
   }
   return data
 }

--- a/demo/src/components/Layout.tsx
+++ b/demo/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Outlet, Link, useNavigate } from 'react-router-dom'
 import { useAuth, useGroup } from '../App'
-import { logout } from '../api'
+import { logout, resolveIdentifier } from '../api'
 import { CopyDid } from './CopyDid'
 
 const styles = {
@@ -40,6 +40,7 @@ export function Layout() {
   const navigate = useNavigate()
   const [showGroupInput, setShowGroupInput] = useState(false)
   const [didInput, setDidInput] = useState('')
+  const [didInputError, setDidInputError] = useState('')
 
   const handleLogout = async () => {
     await logout()
@@ -47,11 +48,18 @@ export function Layout() {
     navigate('/login')
   }
 
-  const handleSetGroupDid = () => {
-    if (didInput.trim()) {
-      setGroup({ did: didInput.trim(), handle: '' })
+  const handleSetGroupDid = async () => {
+    const value = didInput.trim()
+    if (!value) return
+    setDidInputError('')
+    try {
+      // Accept a DID or a handle.
+      const { did, handle } = await resolveIdentifier(value)
+      setGroup({ did, handle: handle ?? '' })
       setDidInput('')
       setShowGroupInput(false)
+    } catch (err: any) {
+      setDidInputError(err.message)
     }
   }
 
@@ -123,7 +131,7 @@ export function Layout() {
             </>
           )}
           {showGroupInput && (
-            <div style={{ display: 'flex', gap: 4, marginLeft: 8 }}>
+            <div style={{ display: 'flex', gap: 4, marginLeft: 8, alignItems: 'center' }}>
               <input
                 style={{
                   padding: '3px 8px',
@@ -134,7 +142,7 @@ export function Layout() {
                 }}
                 value={didInput}
                 onChange={(e) => setDidInput(e.target.value)}
-                placeholder="did:plc:..."
+                placeholder="Group DID or handle"
                 onKeyDown={(e) => e.key === 'Enter' && handleSetGroupDid()}
                 autoFocus
               />
@@ -144,6 +152,9 @@ export function Layout() {
               >
                 Set
               </button>
+              {didInputError && (
+                <span style={{ color: '#c0392b', fontSize: 11 }}>{didInputError}</span>
+              )}
             </div>
           )}
         </div>

--- a/demo/src/pages/AuditLog.tsx
+++ b/demo/src/pages/AuditLog.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useGroup } from '../App'
-import { proxyGet } from '../api'
+import { proxyGet, resolveIdentifier } from '../api'
 import { CopyDid } from '../components/CopyDid'
 
 const inputStyle: React.CSSProperties = {
@@ -48,7 +48,8 @@ export function AuditLog() {
     setLoading(true)
     try {
       const params: Record<string, string> = { groupDid }
-      if (actorDid) params.actorDid = actorDid
+      // The actor filter accepts a DID or a handle — resolve to a DID.
+      if (actorDid) params.actorDid = (await resolveIdentifier(actorDid)).did
       if (action) params.action = action
       if (collection) params.collection = collection
       if (paginationCursor) params.cursor = paginationCursor
@@ -88,7 +89,7 @@ export function AuditLog() {
             style={{ ...inputStyle, flex: 1 }}
             value={actorDid}
             onChange={(e) => setActorDid(e.target.value)}
-            placeholder="Filter: Actor DID"
+            placeholder="Filter: Actor DID or handle"
           />
           <input
             style={{ ...inputStyle, flex: 1 }}

--- a/demo/src/pages/Dashboard.tsx
+++ b/demo/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useGroup } from '../App'
-import { proxyGet, proxyPost } from '../api'
+import { proxyGet, proxyPost, resolveIdentifier } from '../api'
 import { CopyDid } from '../components/CopyDid'
 
 const inputStyle: React.CSSProperties = {
@@ -68,8 +68,10 @@ export function Dashboard() {
   const addMember = async () => {
     setActionMsg('')
     try {
-      await proxyPost('app.certified.group.member.add', { groupDid, memberDid: newDid, role: newRole })
-      setActionMsg(`Added ${newDid} as ${newRole}`)
+      // Accept a DID or a handle — resolve to a DID for member.add.
+      const { did } = await resolveIdentifier(newDid)
+      await proxyPost('app.certified.group.member.add', { groupDid, memberDid: did, role: newRole })
+      setActionMsg(`Added ${did} as ${newRole}`)
       setNewDid('')
       fetchMembers()
     } catch (err: any) {
@@ -187,7 +189,7 @@ export function Dashboard() {
             style={{ ...inputStyle, flex: 1 }}
             value={newDid}
             onChange={(e) => setNewDid(e.target.value)}
-            placeholder="Member DID (did:plc:...)"
+            placeholder="Member DID or handle (did:plc:… or alice.example.com)"
           />
           <select style={inputStyle} value={newRole} onChange={(e) => setNewRole(e.target.value)}>
             <option value="member">member</option>

--- a/railway-demo.toml
+++ b/railway-demo.toml
@@ -1,7 +1,13 @@
 # Railway config for the DEMO app — a separate Railway service from the group
-# service (which uses the repo-root railway.toml). Set the service's Root
-# Directory to `demo`; Railway then auto-detects this file (demo/railway.toml)
-# and builds demo/Dockerfile. No config-as-code path needs to be set.
+# service (which uses the repo-root railway.toml). The demo builds with the REPO
+# ROOT as context so it can copy the repo-root lexicons/ at build time (the
+# custom CGS lexicons are never duplicated into demo/).
+#
+# On the demo Railway service, set:
+#   - Root Directory:        the repo root (default / unset)
+#   - Config-as-code path:   railway-demo.toml (this file)
+# (Both are needed because the repo root already has railway.toml for the group
+# service, so this demo config must be selected explicitly.)
 #
 # Required service variables (set in Railway, not committed):
 #   GROUP_SERVICE_URL   e.g. https://dev.groups.certified.app
@@ -14,7 +20,7 @@
 
 [build]
 builder = "dockerfile"
-dockerfilePath = "Dockerfile"
+dockerfilePath = "demo/Dockerfile"
 
 [deploy]
 healthcheckPath = "/api/health"

--- a/railway-demo.toml
+++ b/railway-demo.toml
@@ -1,7 +1,6 @@
 # Railway config for the DEMO app — a separate Railway service from the group
 # service (which uses the repo-root railway.toml). The demo builds with the REPO
-# ROOT as context so it can copy the repo-root lexicons/ at build time (the
-# custom CGS lexicons are never duplicated into demo/).
+# ROOT as context; demo/Dockerfile copies only demo/*.
 #
 # On the demo Railway service, set:
 #   - Root Directory:        the repo root (default / unset)


### PR DESCRIPTION
Fixes found by deploying the demo to Railway (pr-base) and driving it in a real browser — the whole API-key surface plus login/register/records/upload. All verified live against the deployed preview while authenticated as a real ePDS account. Full test report: `tmp/DEMO-API-KEY-TEST-REPORT.md`.

<img width="1068" height="1358" alt="image" src="https://github.com/user-attachments/assets/8fb7f6a4-ae94-4166-8b99-5143fb4a765b" />


## Bugs fixed

1. **`ERR_INVALID_URL` boot crash** (`ecfa508`) — `NodeOAuthClient` was constructed at module load with an empty `client_id` when OAuth env was unset, throwing on import and taking the whole BFF (and `/api/health`) down → Railway healthcheck failed. Now built lazily via `getOauthClient()`, which throws a clear "OAuth is not configured" error only on the OAuth routes; the server boots regardless.

2. **All proxied calls failed: `"could not resolve proxy did service url"`** (`d503cb0`) — the proxy routes used `agent.withProxy('certified_group', groupDid)`, making the **user's PDS** resolve the group DID's `#certified_group` service. The ePDS's cached DID document for a freshly-registered group predated the group's service-entry PLC op (observed: ePDS `describeRepo` returned only `#atproto_pds`), so it failed — breaking member.list, audit.query, keys.create/list/delete, records, and blob upload. Replaced the service-proxy path with a **direct service-auth call** (`getServiceAuth({aud: serviceDid, lxm})` + `repo` on the querystring/body), matching the group service's verifier and never touching PDS DID-doc caching. Also removed the now-dead `createProxyAgent` + client-side lexicon loading.

3. **Blob upload crashed: `Cannot read properties of undefined (reading 'user')`** (`2e561e9`) — `/api/upload-blob` was mounted before the session middleware, so `req.session` was undefined. Moved `session()` ahead of the raw upload route (it doesn't consume the body).

4. **Errors hid the real cause** (`b8a3a82`) — the client showed only the terse XRPC error name (`InvalidRequest`) instead of the message (`No invite code provided`). Added `formatApiError` to prefer the human message and append the error name.

5. **Dead lexicon copy removed** (`78f167e`) — no longer needed once the proxy stopped registering client-side lexicons. Build context stays the repo root (only `demo/*` copied).

## Verified live (all pass)

keys.create / list / **use via `X-API-Key`** / **read scope-denial (403)** / **write-scoped createRecord** / **write scope-denial (403)** / blob-scope key / **revoke** / **use-revoked (401)** / method allowlist (400). Plus member.list, audit.query, createRecord, blob upload, and the API Keys UI (mint→show-once banner, Use-a-key button, Revoke). All pages render clean.

Follows #44 (demo API-key feature), #45 (railway config into demo/), #46 (Docker build). The pr-base demo Railway service deploys this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed session handling to ensure proper availability across all routes.
  * Improved error messages with clearer formatting and better context.

* **Improvements**
  * Enhanced OAuth initialization with better runtime validation and configuration error reporting.
  * Streamlined group service integration for more reliable authenticated operations.

* **Chores**
  * Updated deployment configuration and build context handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->