### PR TITLE
feat(demo): show handles primarily, DIDs as secondary

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -8,7 +8,8 @@
     "dev:server": "tsx watch server/index.ts",
     "dev:client": "vite",
     "build": "vite build && tsc -p tsconfig.server.json",
-    "start": "node dist-server/index.js"
+    "start": "node dist-server/index.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "@atproto/api": "^0.19.3",
@@ -35,6 +36,7 @@
     "react-router-dom": "^7.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.5.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^2.1.9"
   }
 }

--- a/demo/pnpm-lock.yaml
+++ b/demo/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       vite:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@25.5.0)(tsx@4.21.0)
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@25.5.0)
 
 packages:
 
@@ -236,6 +239,12 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -248,6 +257,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -258,6 +273,12 @@ packages:
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -272,6 +293,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -284,6 +311,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -294,6 +327,12 @@ packages:
     resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -308,6 +347,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -318,6 +363,12 @@ packages:
     resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -332,6 +383,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -342,6 +399,12 @@ packages:
     resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -356,6 +419,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -366,6 +435,12 @@ packages:
     resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -380,6 +455,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -390,6 +471,12 @@ packages:
     resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -404,6 +491,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -416,6 +509,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -426,6 +525,12 @@ packages:
     resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -452,6 +557,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -474,6 +585,12 @@ packages:
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -500,6 +617,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -511,6 +634,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -524,6 +653,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -534,6 +669,12 @@ packages:
     resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -784,6 +925,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -801,6 +971,10 @@ packages:
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   await-lock@2.2.2:
     resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
@@ -830,6 +1004,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -841,9 +1019,17 @@ packages:
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -917,6 +1103,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -954,9 +1144,17 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -975,9 +1173,16 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-session@1.19.0:
     resolution: {integrity: sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==}
@@ -1096,11 +1301,17 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1188,6 +1399,13 @@ packages:
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1321,13 +1539,22 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -1352,9 +1579,27 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   tlds@1.261.0:
     resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
@@ -1426,6 +1671,42 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -1465,6 +1746,36 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -1754,10 +2065,16 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -1766,10 +2083,16 @@ snapshots:
   '@esbuild/android-arm64@0.27.4':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -1778,10 +2101,16 @@ snapshots:
   '@esbuild/android-x64@0.27.4':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -1790,10 +2119,16 @@ snapshots:
   '@esbuild/darwin-x64@0.27.4':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -1802,10 +2137,16 @@ snapshots:
   '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -1814,10 +2155,16 @@ snapshots:
   '@esbuild/linux-arm@0.27.4':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -1826,10 +2173,16 @@ snapshots:
   '@esbuild/linux-loong64@0.27.4':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -1838,16 +2191,25 @@ snapshots:
   '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -1862,6 +2224,9 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -1872,6 +2237,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -1886,10 +2254,16 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -1898,10 +2272,16 @@ snapshots:
   '@esbuild/win32-arm64@0.27.4':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -2117,6 +2497,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.5.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@25.5.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -2131,6 +2551,8 @@ snapshots:
   append-field@1.0.0: {}
 
   array-flatten@1.1.1: {}
+
+  assertion-error@2.0.1: {}
 
   await-lock@2.2.2: {}
 
@@ -2169,6 +2591,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -2181,10 +2605,20 @@ snapshots:
 
   caniuse-lite@1.0.30001780: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.3: {}
 
   cliui@8.0.1:
     dependencies:
@@ -2247,6 +2681,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   depd@2.0.0: {}
 
   destroy@1.2.0: {}
@@ -2271,9 +2707,37 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2337,7 +2801,13 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   etag@1.8.1: {}
+
+  expect-type@1.3.0: {}
 
   express-session@1.19.0:
     dependencies:
@@ -2481,11 +2951,17 @@ snapshots:
 
   json5@2.2.3: {}
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
 
@@ -2546,6 +3022,10 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-to-regexp@0.1.12: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -2722,9 +3202,15 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -2750,10 +3236,20 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   tlds@1.261.0: {}
 
@@ -2807,6 +3303,33 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite-node@2.1.9(@types/node@25.5.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@25.5.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@25.5.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.8
+      rollup: 4.59.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+      fsevents: 2.3.3
+
   vite@6.4.1(@types/node@25.5.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
@@ -2819,6 +3342,46 @@ snapshots:
       '@types/node': 25.5.0
       fsevents: 2.3.3
       tsx: 4.21.0
+
+  vitest@2.1.9(@types/node@25.5.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.5.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@25.5.0)
+      vite-node: 2.1.9(@types/node@25.5.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/demo/server/routes/resolve.test.ts
+++ b/demo/server/routes/resolve.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { didDocumentUrl } from './resolve.js'
+
+// didDocumentUrl maps a DID to where its document lives — the most error-prone
+// part of reverse handle resolution (did:web path/host encoding). Network
+// fetching and alsoKnownAs parsing are covered end-to-end by the live browser
+// test; these assert the URL construction that a unit test can pin down.
+describe('didDocumentUrl', () => {
+  it('maps a did:plc to the PLC directory', () => {
+    expect(didDocumentUrl('did:plc:qvay7faxuyobqaftqfltlvhf')).toBe(
+      'https://plc.directory/did%3Aplc%3Aqvay7faxuyobqaftqfltlvhf',
+    )
+  })
+
+  it('maps a bare did:web to the host well-known document', () => {
+    expect(didDocumentUrl('did:web:example.com')).toBe('https://example.com/.well-known/did.json')
+  })
+
+  it('maps a did:web with a path (colon-separated segments)', () => {
+    expect(didDocumentUrl('did:web:example.com:user:alice')).toBe(
+      'https://example.com/user/alice/.well-known/did.json',
+    )
+  })
+
+  it('returns null for an unsupported DID method', () => {
+    expect(didDocumentUrl('did:key:z6Mk')).toBeNull()
+    expect(didDocumentUrl('not-a-did')).toBeNull()
+  })
+})

--- a/demo/server/routes/resolve.test.ts
+++ b/demo/server/routes/resolve.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { didDocumentUrl } from './resolve.js'
+import { didDocumentUrl, isPublicHost } from './resolve.js'
 
 // didDocumentUrl maps a DID to where its document lives — the most error-prone
 // part of reverse handle resolution (did:web path/host encoding). Network
@@ -25,5 +25,46 @@ describe('didDocumentUrl', () => {
   it('returns null for an unsupported DID method', () => {
     expect(didDocumentUrl('did:key:z6Mk')).toBeNull()
     expect(didDocumentUrl('not-a-did')).toBeNull()
+  })
+
+  it('returns null for a did:web pointing at a non-public host (SSRF guard)', () => {
+    expect(didDocumentUrl('did:web:localhost')).toBeNull()
+    expect(didDocumentUrl('did:web:127.0.0.1')).toBeNull()
+    expect(didDocumentUrl('did:web:10.0.0.5')).toBeNull()
+  })
+
+  it('returns null for a did:web with malformed percent-encoding', () => {
+    expect(didDocumentUrl('did:web:%ZZ')).toBeNull()
+  })
+})
+
+describe('isPublicHost', () => {
+  it('accepts public dotted hostnames', () => {
+    expect(isPublicHost('example.com')).toBe(true)
+    expect(isPublicHost('epds1.test.certified.app')).toBe(true)
+  })
+
+  it('rejects loopback, private, link-local and internal hosts', () => {
+    for (const h of [
+      'localhost',
+      '127.0.0.1',
+      '0.0.0.0',
+      '::1',
+      '10.0.0.1',
+      '192.168.1.1',
+      '169.254.1.1',
+      '172.16.0.1',
+      '172.31.255.255',
+      'db.internal',
+      'host.local',
+      'nodothost',
+    ]) {
+      expect(isPublicHost(h), h).toBe(false)
+    }
+  })
+
+  it('does not over-block public 172.x outside the private range', () => {
+    expect(isPublicHost('172.15.0.1')).toBe(true)
+    expect(isPublicHost('172.32.0.1')).toBe(true)
   })
 })

--- a/demo/server/routes/resolve.ts
+++ b/demo/server/routes/resolve.ts
@@ -3,38 +3,74 @@ import { Router } from 'express'
 const router = Router()
 const EPDS_URL = process.env.EPDS_URL || 'https://epds1.test.certified.app'
 const PLC_URL = process.env.PLC_URL || 'https://plc.directory'
+// Bound DID-document fetches so a stalled host can't tie up a BFF worker
+// (mirrors the AbortController pattern in routes/keys.ts).
+const DOC_FETCH_TIMEOUT_MS = 5_000
 
 /**
  * Resolve a DID to its primary handle by reading the DID document's
  * `alsoKnownAs` (the first `at://` entry, per atproto convention). Returns null
  * when the DID does not resolve or declares no handle — callers fall back to
- * showing the DID. Only `did:plc:` (via the PLC directory) and `did:web:`
- * (via `/.well-known/did.json`) are supported; other methods return null.
+ * showing the DID. Only `did:plc:` (via the PLC directory) and `did:web:` on a
+ * public host (via `/.well-known/did.json`) are supported; anything else
+ * returns null. The fetch is time-bounded.
  */
 async function didToHandle(did: string): Promise<string | null> {
   const docUrl = didDocumentUrl(did)
   if (!docUrl) return null
-  const upstream = await fetch(docUrl)
-  if (!upstream.ok) return null
-  const doc = (await upstream.json().catch(() => null)) as { alsoKnownAs?: unknown } | null
-  const aka = Array.isArray(doc?.alsoKnownAs) ? doc.alsoKnownAs : []
-  const atUri = aka.find((v): v is string => typeof v === 'string' && v.startsWith('at://'))
-  return atUri ? atUri.slice('at://'.length) : null
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), DOC_FETCH_TIMEOUT_MS)
+  try {
+    const upstream = await fetch(docUrl, { signal: controller.signal })
+    if (!upstream.ok) return null
+    const doc = (await upstream.json().catch(() => null)) as { alsoKnownAs?: unknown } | null
+    const aka = Array.isArray(doc?.alsoKnownAs) ? doc.alsoKnownAs : []
+    const atUri = aka.find((v): v is string => typeof v === 'string' && v.startsWith('at://'))
+    return atUri ? atUri.slice('at://'.length) : null
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
 }
 
-/** The URL of a DID's document, or null for an unsupported DID method. */
+/**
+ * Reject `did:web` hosts that point at the local network. The BFF fetches the
+ * DID document server-side, so an attacker-supplied `did:web:` could otherwise
+ * coax it into requesting an internal address (SSRF). This is a syntactic guard
+ * — it blocks the obvious internal targets (loopback, RFC1918, link-local,
+ * `.local`/`.internal`, bare/no-dot hosts) without doing DNS resolution.
+ */
+export function isPublicHost(host: string): boolean {
+  const h = host.toLowerCase()
+  if (!h || !h.includes('.')) return false // bare hostnames (e.g. "localhost")
+  if (h === 'localhost' || h.endsWith('.local') || h.endsWith('.internal')) return false
+  if (h === '127.0.0.1' || h.startsWith('127.') || h === '0.0.0.0' || h === '::1') return false
+  // RFC1918 / link-local IPv4 ranges.
+  if (h.startsWith('10.') || h.startsWith('192.168.') || h.startsWith('169.254.')) return false
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return false
+  return true
+}
+
+/** The URL of a DID's document, or null for an unsupported/unsafe DID. */
 export function didDocumentUrl(did: string): string | null {
   if (did.startsWith('did:plc:')) {
     return `${PLC_URL.replace(/\/$/, '')}/${encodeURIComponent(did)}`
   }
   if (did.startsWith('did:web:')) {
-    // did:web:<host>[:<path>] → https://<host>[/<path>]/.well-known/did.json
-    const rest = did.slice('did:web:'.length)
-    const parts = rest.split(':').map(decodeURIComponent)
-    const host = parts[0]
-    const path = parts.slice(1).join('/')
-    const base = path ? `https://${host}/${path}` : `https://${host}`
-    return `${base}/.well-known/did.json`
+    // did:web:<host>[:<path>] → https://<host>[/<path>]/.well-known/did.json.
+    // decodeURIComponent throws on malformed percent-encoding; treat that (and
+    // a non-public host) as "no document" rather than letting it propagate.
+    try {
+      const parts = did.slice('did:web:'.length).split(':').map(decodeURIComponent)
+      const host = parts[0]
+      if (!isPublicHost(host)) return null
+      const path = parts.slice(1).join('/')
+      const base = path ? `https://${host}/${path}` : `https://${host}`
+      return `${base}/.well-known/did.json`
+    } catch {
+      return null
+    }
   }
   return null
 }
@@ -78,7 +114,7 @@ router.get('/', async (req, res) => {
 const MAX_BATCH = 100
 
 /**
- * POST /api/resolve-handles  body: { dids: string[] }
+ * POST /api/resolve/handles  body: { dids: string[] }
  *
  * Reverse-resolve a batch of DIDs to their handles for display (handle-primary,
  * DID-secondary in the UI). Returns `{ handles: { [did]: handle | null } }`;

--- a/demo/server/routes/resolve.ts
+++ b/demo/server/routes/resolve.ts
@@ -2,6 +2,42 @@ import { Router } from 'express'
 
 const router = Router()
 const EPDS_URL = process.env.EPDS_URL || 'https://epds1.test.certified.app'
+const PLC_URL = process.env.PLC_URL || 'https://plc.directory'
+
+/**
+ * Resolve a DID to its primary handle by reading the DID document's
+ * `alsoKnownAs` (the first `at://` entry, per atproto convention). Returns null
+ * when the DID does not resolve or declares no handle — callers fall back to
+ * showing the DID. Only `did:plc:` (via the PLC directory) and `did:web:`
+ * (via `/.well-known/did.json`) are supported; other methods return null.
+ */
+async function didToHandle(did: string): Promise<string | null> {
+  const docUrl = didDocumentUrl(did)
+  if (!docUrl) return null
+  const upstream = await fetch(docUrl)
+  if (!upstream.ok) return null
+  const doc = (await upstream.json().catch(() => null)) as { alsoKnownAs?: unknown } | null
+  const aka = Array.isArray(doc?.alsoKnownAs) ? doc.alsoKnownAs : []
+  const atUri = aka.find((v): v is string => typeof v === 'string' && v.startsWith('at://'))
+  return atUri ? atUri.slice('at://'.length) : null
+}
+
+/** The URL of a DID's document, or null for an unsupported DID method. */
+export function didDocumentUrl(did: string): string | null {
+  if (did.startsWith('did:plc:')) {
+    return `${PLC_URL.replace(/\/$/, '')}/${encodeURIComponent(did)}`
+  }
+  if (did.startsWith('did:web:')) {
+    // did:web:<host>[:<path>] → https://<host>[/<path>]/.well-known/did.json
+    const rest = did.slice('did:web:'.length)
+    const parts = rest.split(':').map(decodeURIComponent)
+    const host = parts[0]
+    const path = parts.slice(1).join('/')
+    const base = path ? `https://${host}/${path}` : `https://${host}`
+    return `${base}/.well-known/did.json`
+  }
+  return null
+}
 
 /**
  * GET /api/resolve?identifier=<did-or-handle>
@@ -37,6 +73,41 @@ router.get('/', async (req, res) => {
   } catch (err: any) {
     res.status(502).json({ error: err?.message || 'Handle resolution failed' })
   }
+})
+
+const MAX_BATCH = 100
+
+/**
+ * POST /api/resolve-handles  body: { dids: string[] }
+ *
+ * Reverse-resolve a batch of DIDs to their handles for display (handle-primary,
+ * DID-secondary in the UI). Returns `{ handles: { [did]: handle | null } }`;
+ * a DID that does not resolve maps to null so the caller shows the DID instead.
+ * Resolution is best-effort and per-DID independent — one failure never fails
+ * the batch. Done server-side to keep DID-doc fetches off the browser.
+ */
+router.post('/handles', async (req, res) => {
+  const raw = (req.body as { dids?: unknown })?.dids
+  if (!Array.isArray(raw)) {
+    return res.status(400).json({ error: 'Body must be { dids: string[] }' })
+  }
+  // De-duplicate and keep only well-formed DID strings, capped to bound fan-out.
+  const dids = [...new Set(raw.filter((d): d is string => typeof d === 'string' && d.startsWith('did:')))].slice(
+    0,
+    MAX_BATCH,
+  )
+
+  const entries = await Promise.all(
+    dids.map(async (did) => {
+      try {
+        return [did, await didToHandle(did)] as const
+      } catch {
+        return [did, null] as const
+      }
+    }),
+  )
+
+  res.json({ handles: Object.fromEntries(entries) })
 })
 
 export default router

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, createContext, useContext } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import { getMe, setOnUnauthorized } from './api'
+import { getMe, setOnUnauthorized, resolveHandles } from './api'
 import { Layout } from './components/Layout'
 import { Login } from './pages/Login'
 import { Register } from './pages/Register'
@@ -83,6 +83,26 @@ export function App() {
       .catch(() => setUser(null))
       .finally(() => setLoading(false))
   }, [])
+
+  // Backfill the active group's handle when it is missing — e.g. the group was
+  // entered as a raw DID, or restored from legacy DID-only storage. Reverse-
+  // resolving here means every consumer (banner, page headers) gets the
+  // human-readable handle without each having to resolve it. Best-effort: on
+  // failure the DID simply remains the display value.
+  useEffect(() => {
+    if (!group || group.handle) return
+    let cancelled = false
+    resolveHandles([group.did])
+      .then((res) => {
+        const handle = res.handles[group.did]
+        if (!cancelled && handle) setGroup({ did: group.did, handle })
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [group?.did, group?.handle])
 
   if (loading) {
     return <div style={{ padding: 40, textAlign: 'center' }}>Loading...</div>

--- a/demo/src/api.ts
+++ b/demo/src/api.ts
@@ -57,6 +57,17 @@ export const resolveIdentifier = (identifier: string) =>
     `/resolve?identifier=${encodeURIComponent(identifier.trim())}`,
   )
 
+/**
+ * Reverse-resolve a batch of DIDs to their handles for display (handle-primary,
+ * DID-secondary). Returns a map keyed by DID; an unresolved DID maps to null so
+ * the caller falls back to showing the DID. Best-effort — never throws per-DID.
+ */
+export const resolveHandles = (dids: string[]) =>
+  request<{ handles: Record<string, string | null> }>('/resolve/handles', {
+    method: 'POST',
+    body: JSON.stringify({ dids }),
+  })
+
 // Register (requires auth — owner DID comes from session, service auth proves DID control)
 export const registerGroup = (body: { handle: string }) =>
   request<{ groupDid: string; handle: string }>('/register', { method: 'POST', body: JSON.stringify(body) })

--- a/demo/src/components/CopyDid.tsx
+++ b/demo/src/components/CopyDid.tsx
@@ -24,6 +24,10 @@ export function CopyDid({ did, truncate, style, label }: CopyDidProps) {
 
   const display = label ?? (truncate ? `${did.slice(0, 20)}...` : did)
 
+  // Signal a successful copy without changing the rendered text — swapping in
+  // "Copied!" would change the element's width and reflow the surrounding
+  // layout. Instead the text stays put and briefly flashes green; the tooltip
+  // carries the "Copied!" wording.
   return (
     <span
       onClick={handleClick}
@@ -33,9 +37,10 @@ export function CopyDid({ did, truncate, style, label }: CopyDidProps) {
         fontFamily: 'monospace',
         borderBottom: '1px dashed #999',
         ...style,
+        ...(copied ? { color: '#27ae60', borderBottomColor: '#27ae60' } : null),
       }}
     >
-      {copied ? 'Copied!' : display}
+      {display}
     </span>
   )
 }

--- a/demo/src/components/CopyDid.tsx
+++ b/demo/src/components/CopyDid.tsx
@@ -4,9 +4,15 @@ interface CopyDidProps {
   did: string
   truncate?: boolean
   style?: React.CSSProperties
+  /**
+   * Text to show instead of the DID itself (the full DID is still what gets
+   * copied, and appears in the hover tooltip). Used by {@link HandleId} compact
+   * mode to render a handle that copies its DID. Ignored when `truncate` is set.
+   */
+  label?: string
 }
 
-export function CopyDid({ did, truncate, style }: CopyDidProps) {
+export function CopyDid({ did, truncate, style, label }: CopyDidProps) {
   const [copied, setCopied] = useState(false)
 
   const handleClick = () => {
@@ -15,7 +21,7 @@ export function CopyDid({ did, truncate, style }: CopyDidProps) {
     setTimeout(() => setCopied(false), 1500)
   }
 
-  const display = truncate ? `${did.slice(0, 20)}...` : did
+  const display = label ?? (truncate ? `${did.slice(0, 20)}...` : did)
 
   return (
     <span

--- a/demo/src/components/CopyDid.tsx
+++ b/demo/src/components/CopyDid.tsx
@@ -7,7 +7,8 @@ interface CopyDidProps {
   /**
    * Text to show instead of the DID itself (the full DID is still what gets
    * copied, and appears in the hover tooltip). Used by {@link HandleId} compact
-   * mode to render a handle that copies its DID. Ignored when `truncate` is set.
+   * mode to render a handle that copies its DID. Takes precedence over
+   * `truncate` when both are set.
    */
   label?: string
 }

--- a/demo/src/components/HandleId.tsx
+++ b/demo/src/components/HandleId.tsx
@@ -1,0 +1,65 @@
+import { CopyDid } from './CopyDid'
+
+/**
+ * Display an atproto identity (a group or a member/actor) with the human-readable
+ * **handle as the primary element** and the DID as a secondary one — DIDs are
+ * opaque, handles are not, so handles lead everywhere.
+ *
+ * Layout, by available space:
+ *  - `stacked` — handle on top, a copyable DID line beneath it. For headers and
+ *    other places with vertical room.
+ *  - `inline` — handle followed by a dimmed, copyable DID on the same line. For
+ *    table cells / bars with horizontal room.
+ *  - `compact` — handle only; the DID is shown on hover (native tooltip) and is
+ *    still click-to-copy. For cramped spots where both would crowd.
+ *
+ * When the handle is unknown (not yet resolved, or a DID that declares none) the
+ * DID becomes the primary element via {@link CopyDid}, so nothing is ever blank.
+ */
+type HandleIdLayout = 'stacked' | 'inline' | 'compact'
+
+interface HandleIdProps {
+  did: string
+  /** The resolved handle, or null/undefined when unknown (falls back to the DID). */
+  handle?: string | null
+  layout?: HandleIdLayout
+  /** Optional style for the primary (handle) element. */
+  style?: React.CSSProperties
+}
+
+const handleStyle: React.CSSProperties = {
+  fontFamily:
+    'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+  fontWeight: 600,
+}
+
+export function HandleId({ did, handle, layout = 'inline', style }: HandleIdProps) {
+  // No handle to lead with — show the DID as the primary, copyable element.
+  if (!handle) {
+    return <CopyDid did={did} style={style} />
+  }
+
+  if (layout === 'compact') {
+    // Handle only; the DID is the tooltip and is what a click copies.
+    return <CopyDid did={did} label={handle} style={{ ...handleStyle, ...style }} />
+  }
+
+  if (layout === 'stacked') {
+    return (
+      <span style={{ display: 'inline-flex', flexDirection: 'column', gap: 2 }}>
+        <span style={{ ...handleStyle, ...style }}>{handle}</span>
+        <CopyDid did={did} style={{ opacity: 0.6, fontSize: 11 }} />
+      </span>
+    )
+  }
+
+  // inline
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
+      <span style={{ ...handleStyle, ...style }} title={did}>
+        {handle}
+      </span>
+      <CopyDid did={did} style={{ opacity: 0.6, fontSize: 11 }} />
+    </span>
+  )
+}

--- a/demo/src/components/Layout.tsx
+++ b/demo/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Outlet, Link, useNavigate } from 'react-router-dom'
 import { useAuth, useGroup } from '../App'
 import { logout, resolveIdentifier } from '../api'
 import { CopyDid } from './CopyDid'
+import { HandleId } from './HandleId'
 
 const styles = {
   nav: {
@@ -96,12 +97,12 @@ export function Layout() {
           {group ? (
             <>
               <span style={{ fontWeight: 600 }}>Active group:</span>
-              <code style={{ fontSize: 12, background: '#fff', padding: '2px 8px', borderRadius: 4 }}>
-                {group.handle || <CopyDid did={group.did} />}
-              </code>
-              {group.handle && (
-                <CopyDid did={group.did} style={{ opacity: 0.6, fontSize: 11 }} />
-              )}
+              <HandleId
+                did={group.did}
+                handle={group.handle}
+                layout="inline"
+                style={{ fontSize: 12, background: '#fff', padding: '2px 8px', borderRadius: 4 }}
+              />
               <button
                 onClick={() => setShowGroupInput(!showGroupInput)}
                 style={{ ...styles.btn, color: '#1a1a2e', borderColor: '#90a4ae', fontSize: 12, padding: '2px 8px' }}

--- a/demo/src/pages/ApiKeys.tsx
+++ b/demo/src/pages/ApiKeys.tsx
@@ -9,6 +9,7 @@ import {
   type CreatedApiKey,
 } from '../api'
 import { JsonEditor } from '../components/JsonEditor'
+import { HandleId } from '../components/HandleId'
 import { COLLECTIONS, recordTemplate } from '../collections'
 
 // The service binds the `aud` for rpc: scopes, so clients pass the friendly
@@ -293,7 +294,10 @@ export function ApiKeys() {
 
   return (
     <div style={{ maxWidth: 820 }}>
-      <h2>API keys</h2>
+      <h2 style={{ marginBottom: 4 }}>API keys</h2>
+      <div style={{ marginBottom: 12 }}>
+        <HandleId did={group.did} handle={group.handle} layout="stacked" style={{ fontSize: 16 }} />
+      </div>
       <p style={{ color: '#555', fontSize: 14 }}>
         Mint a long-lived, scope-limited key an external backend can use via the{' '}
         <code>X-API-Key</code> header — no owner session, no 2-minute JWT refresh. The plaintext is

--- a/demo/src/pages/AuditLog.tsx
+++ b/demo/src/pages/AuditLog.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useGroup } from '../App'
 import { proxyGet, resolveIdentifier } from '../api'
-import { CopyDid } from '../components/CopyDid'
+import { HandleId } from '../components/HandleId'
+import { useHandles } from '../useHandles'
 
 const inputStyle: React.CSSProperties = {
   padding: '8px 12px',
@@ -42,6 +43,9 @@ export function AuditLog() {
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
 
+  // Reverse-resolve actor DIDs so the Actor column leads with the handle.
+  const handles = useHandles(entries.map((e) => e.actorDid))
+
   const fetchEntries = async (paginationCursor?: string) => {
     if (!groupDid) return
     setError('')
@@ -81,7 +85,10 @@ export function AuditLog() {
 
   return (
     <div>
-      <h2 style={{ marginBottom: 16 }}>Audit Log</h2>
+      <h2 style={{ marginBottom: 4 }}>Audit Log</h2>
+      <div style={{ marginBottom: 16 }}>
+        <HandleId did={group.did} handle={group.handle} layout="stacked" style={{ fontSize: 16 }} />
+      </div>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 }}>
         <div style={{ display: 'flex', gap: 8 }}>
@@ -129,7 +136,9 @@ export function AuditLog() {
               {entries.map((e) => (
                 <tr key={e.id} style={{ borderBottom: '1px solid #eee' }}>
                   <td style={{ padding: 8 }}>{e.id}</td>
-                  <td style={{ padding: 8, fontSize: 11 }}><CopyDid did={e.actorDid} /></td>
+                  <td style={{ padding: 8, fontSize: 11 }}>
+                    <HandleId did={e.actorDid} handle={handles[e.actorDid]} layout="compact" />
+                  </td>
                   <td style={{ padding: 8 }}>{e.action}</td>
                   <td style={{ padding: 8, fontSize: 11 }}>{e.collection || '-'}</td>
                   <td style={{ padding: 8, fontFamily: 'monospace', fontSize: 11 }}>{e.rkey || '-'}</td>

--- a/demo/src/pages/Dashboard.tsx
+++ b/demo/src/pages/Dashboard.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react'
 import { useGroup } from '../App'
 import { proxyGet, proxyPost, resolveIdentifier } from '../api'
-import { CopyDid } from '../components/CopyDid'
+import { HandleId } from '../components/HandleId'
+import { useHandles } from '../useHandles'
 
 const inputStyle: React.CSSProperties = {
   padding: '8px 12px',
@@ -44,6 +45,10 @@ export function Dashboard() {
   const [actionMsg, setActionMsg] = useState('')
 
   const groupDid = group?.did || ''
+
+  // Reverse-resolve the DIDs shown in the table (members + their adders) so the
+  // table can lead with handles; unresolved DIDs fall back to the DID.
+  const handles = useHandles(members.flatMap((m) => [m.did, m.addedBy]))
 
   const fetchMembers = async () => {
     if (!groupDid) return
@@ -114,7 +119,11 @@ export function Dashboard() {
 
   return (
     <div>
-      <h2 style={{ marginBottom: 16 }}>Dashboard</h2>
+      <h2 style={{ marginBottom: 4 }}>Dashboard</h2>
+      {/* Group identity: handle leads, DID is the secondary copyable line. */}
+      <div style={{ marginBottom: 16 }}>
+        <HandleId did={group.did} handle={group.handle} layout="stacked" style={{ fontSize: 16 }} />
+      </div>
 
       {error && <div style={{ color: '#e74c3c', marginBottom: 12, fontSize: 13 }}>{error}</div>}
       {actionMsg && <div style={{ color: '#2196f3', marginBottom: 12, fontSize: 13 }}>{actionMsg}</div>}
@@ -124,7 +133,7 @@ export function Dashboard() {
         <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: 24, fontSize: 14 }}>
           <thead>
             <tr style={{ borderBottom: '2px solid #ddd', textAlign: 'left' }}>
-              <th style={{ padding: 8 }}>DID</th>
+              <th style={{ padding: 8 }}>Member</th>
               <th style={{ padding: 8 }}>Role</th>
               <th style={{ padding: 8 }}>Added By</th>
               <th style={{ padding: 8 }}>Added At</th>
@@ -134,7 +143,9 @@ export function Dashboard() {
           <tbody>
             {members.map((m) => (
               <tr key={m.did} style={{ borderBottom: '1px solid #eee' }}>
-                <td style={{ padding: 8, fontSize: 12 }}><CopyDid did={m.did} /></td>
+                <td style={{ padding: 8, fontSize: 12 }}>
+                  <HandleId did={m.did} handle={handles[m.did]} layout="compact" />
+                </td>
                 <td style={{ padding: 8 }}>
                   <span style={{
                     padding: '2px 8px',
@@ -146,7 +157,9 @@ export function Dashboard() {
                     {m.role}
                   </span>
                 </td>
-                <td style={{ padding: 8, fontSize: 12 }}><CopyDid did={m.addedBy} /></td>
+                <td style={{ padding: 8, fontSize: 12 }}>
+                  <HandleId did={m.addedBy} handle={handles[m.addedBy]} layout="compact" />
+                </td>
                 <td style={{ padding: 8, fontSize: 12 }}>{new Date(m.addedAt).toLocaleString()}</td>
                 <td style={{ padding: 8, display: 'flex', gap: 4 }}>
                   <select

--- a/demo/src/pages/Records.tsx
+++ b/demo/src/pages/Records.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useGroup } from '../App'
 import { proxyPost } from '../api'
 import { JsonEditor } from '../components/JsonEditor'
+import { HandleId } from '../components/HandleId'
 import { COLLECTIONS, recordTemplate } from '../collections'
 
 /** Pretty-printed starter JSON for a collection, stamped with the current time. */
@@ -136,7 +137,10 @@ export function Records() {
 
   return (
     <div>
-      <h2 style={{ marginBottom: 16 }}>Records</h2>
+      <h2 style={{ marginBottom: 4 }}>Records</h2>
+      <div style={{ marginBottom: 16 }}>
+        <HandleId did={group.did} handle={group.handle} layout="stacked" style={{ fontSize: 16 }} />
+      </div>
 
       {/* Tabs */}
       <div style={{ display: 'flex', gap: 2, marginBottom: 0 }}>

--- a/demo/src/pages/Upload.tsx
+++ b/demo/src/pages/Upload.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react'
 import { useGroup } from '../App'
 import { uploadBlob, proxyPost } from '../api'
+import { HandleId } from '../components/HandleId'
 
 const inputStyle: React.CSSProperties = {
   padding: '8px 12px',
@@ -95,7 +96,10 @@ export function Upload() {
 
   return (
     <div>
-      <h2 style={{ marginBottom: 16 }}>Upload Blob</h2>
+      <h2 style={{ marginBottom: 4 }}>Upload Blob</h2>
+      <div style={{ marginBottom: 16 }}>
+        <HandleId did={group.did} handle={group.handle} layout="stacked" style={{ fontSize: 16 }} />
+      </div>
 
       {/* Drop zone */}
       <div

--- a/demo/src/useHandles.ts
+++ b/demo/src/useHandles.ts
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react'
 import { resolveHandles } from './api'
 
+// Matches the server-side cap in server/routes/resolve.ts so we never send a
+// batch the server would silently truncate — instead we send one cap-sized
+// batch per round and let the effect re-run for the remainder.
+const MAX_BATCH = 100
+
 /**
  * Reverse-resolve a set of DIDs to handles for display, returning a `did →
  * handle | null` map. Used by views that list member/actor DIDs (Dashboard,
@@ -8,19 +13,23 @@ import { resolveHandles } from './api'
  *
  * Resolution is best-effort: the map starts empty (callers fall back to the DID
  * via {@link HandleId}) and fills in as it resolves. Only DIDs not already
- * resolved are fetched, so re-renders with the same DIDs cost nothing. A failed
- * batch is swallowed — the UI simply keeps showing DIDs.
+ * resolved are fetched. When more than one batch is needed (> MAX_BATCH unknown
+ * DIDs), each completed batch grows `handles`, which re-runs the effect for the
+ * next batch until none remain. A failed batch is swallowed — the UI keeps
+ * showing DIDs.
  */
 export function useHandles(dids: string[]): Record<string, string | null> {
   const [handles, setHandles] = useState<Record<string, string | null>>({})
 
   // Stable dependency: the sorted set of DIDs, so the effect only re-runs when
-  // the actual DID set changes, not on every array identity change.
+  // the actual DID set changes (not on every array identity), plus the resolved
+  // count so a completed batch triggers the next one for any remainder.
   const key = [...new Set(dids)].sort().join(',')
+  const resolvedCount = Object.keys(handles).length
 
   useEffect(() => {
     const unique = [...new Set(dids)].filter((d) => d && d.startsWith('did:'))
-    const missing = unique.filter((d) => !(d in handles))
+    const missing = unique.filter((d) => !(d in handles)).slice(0, MAX_BATCH)
     if (missing.length === 0) return
 
     let cancelled = false
@@ -34,9 +43,10 @@ export function useHandles(dids: string[]): Record<string, string | null> {
     return () => {
       cancelled = true
     }
-    // `key` captures the meaningful change; `handles`/`dids` are read inside.
+    // `key` + `resolvedCount` capture the meaningful changes; `handles`/`dids`
+    // are read inside and need not trigger on identity alone.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key])
+  }, [key, resolvedCount])
 
   return handles
 }

--- a/demo/src/useHandles.ts
+++ b/demo/src/useHandles.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+import { resolveHandles } from './api'
+
+/**
+ * Reverse-resolve a set of DIDs to handles for display, returning a `did →
+ * handle | null` map. Used by views that list member/actor DIDs (Dashboard,
+ * Audit) so they can lead with the handle and keep the DID secondary.
+ *
+ * Resolution is best-effort: the map starts empty (callers fall back to the DID
+ * via {@link HandleId}) and fills in as it resolves. Only DIDs not already
+ * resolved are fetched, so re-renders with the same DIDs cost nothing. A failed
+ * batch is swallowed — the UI simply keeps showing DIDs.
+ */
+export function useHandles(dids: string[]): Record<string, string | null> {
+  const [handles, setHandles] = useState<Record<string, string | null>>({})
+
+  // Stable dependency: the sorted set of DIDs, so the effect only re-runs when
+  // the actual DID set changes, not on every array identity change.
+  const key = [...new Set(dids)].sort().join(',')
+
+  useEffect(() => {
+    const unique = [...new Set(dids)].filter((d) => d && d.startsWith('did:'))
+    const missing = unique.filter((d) => !(d in handles))
+    if (missing.length === 0) return
+
+    let cancelled = false
+    resolveHandles(missing)
+      .then((res) => {
+        if (!cancelled) setHandles((prev) => ({ ...prev, ...res.handles }))
+      })
+      .catch(() => {
+        // Best-effort: leave the missing DIDs unresolved; HandleId shows the DID.
+      })
+    return () => {
+      cancelled = true
+    }
+    // `key` captures the meaningful change; `handles`/`dids` are read inside.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key])
+
+  return handles
+}

--- a/demo/tsconfig.server.json
+++ b/demo/tsconfig.server.json
@@ -10,5 +10,5 @@
     "esModuleInterop": true
   },
   "include": ["server/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
## What

DIDs (`did:plc:…`) are opaque; handles (`cgs-keytest-pr49.epds1.test.certified.app`) are human-readable. This makes every place the demo shows a group, member, or actor **lead with the handle** and keep the DID as a secondary, still-copyable element — per the UX principle that handles are what people read.

## How

**New `<HandleId>` component** — one place that owns handle-vs-DID display, three layouts by available space:
- `stacked` — handle on top, copyable DID beneath (page headers).
- `inline` — handle + dimmed copyable DID on one line (the active-group banner).
- `compact` — handle only; **DID shows on hover (tooltip) and is what a click copies** (cramped table cells).

When no handle is known it falls back to the DID via `CopyDid`, so nothing is ever blank.

**Reverse DID→handle resolution (new BFF capability).** The existing `/api/resolve` is handle→DID only. Added `POST /api/resolve/handles` that reads a DID document's `alsoKnownAs`:
- `did:plc:` → the PLC directory (`https://plc.directory/<did>`)
- `did:web:` → `https://<host>[/<path>]/.well-known/did.json`

A `useHandles()` hook batch-resolves a view's DIDs, best-effort (the map fills in as it resolves; a failed batch just leaves DIDs showing). De-dupes and caps fan-out at 100.

## Where it shows up

| View | Change |
| --- | --- |
| Active-group **banner** (Layout) | now `<HandleId>` inline (was an ad-hoc `<code>` + dimmed DID) |
| **Dashboard** | group-identity header (handle primary); member table `Member`/`Added By` columns resolve DIDs → handle (compact) |
| **Audit** | group header; `Actor` column resolves actor DIDs → handle (compact) |
| **Records / Upload / API Keys** | group-identity header added (previously showed no group identity at all) |

Member/actor DIDs are *people* — the `member.list`/`audit.query` APIs return only DIDs, so the new reverse-resolution endpoint is what makes their handles displayable.

## Tooling fix

The `collections.test.ts` added in #49 had no way to run from the demo itself — the demo `package.json` had no `vitest` dep or `test` script (it only ran via the repo-root vitest). Added both, plus a unit test for the `did:plc`/`did:web` document-URL mapping. `pnpm test` in `demo/` now runs **11 tests** (7 collections + 4 resolve).

## Testing

- `tsc -p tsconfig.json` (client) and `tsc -p tsconfig.server.json` (BFF) — clean
- `vite build` + server build — clean; no test files emitted into `dist-server`
- `pnpm test` (demo) — 11/11 pass
- `prettier --check` on all touched files — clean
- Docker-equivalent `pnpm install --frozen-lockfile` — succeeds (lockfile updated for the vitest dep)

Will also drive the live preview (handle-primary display, DID tooltips, member/actor resolution) once deployed, as with #49.

No changeset — demo-only, consistent with prior `*(demo)` PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DIDs now display alongside resolved handles across the app.
  * New batch handle-resolution API and a React hook to progressively resolve DID→handle mappings.
  * New reusable identity component with inline/stacked/compact layouts; pages updated to use it.

* **Tests**
  * Added tests covering DID resolution and host validation.

* **Chores**
  * Added test script and testing dependency to the demo project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->