### PR TITLE
feat(api-keys): permission sets (include: scopes) — design + implementation

### DIFF
--- a/.agents/skills/app-development-with-cgs/SKILL.md
+++ b/.agents/skills/app-development-with-cgs/SKILL.md
@@ -289,6 +289,22 @@ For `rpc:` scopes pass the **friendly** `rpc:<method>` name — do **not** add a
 back the canonical form. `InvalidScope` is returned for an unparseable scope, a
 non-RPC method, or an `aud` for a different service.
 
+**Permission sets (`include:`).** The Hypercerts / Certified record types are
+published as permission sets — scope bundles named by one `include:<nsid>` scope:
+`org.hypercerts.permissions.crud` (write on all `org.hypercerts.*` collections)
+and `app.certified.permissions.crud` (write on all `app.certified.*`). Two sets,
+never one: a set may only reference its own namespace authority. Caveats for an
+agent:
+
+- **OAuth path: usable now.** An app reaching CGS via OAuth + service proxying
+  requests `include:<nsid>` as a scope; the user's PDS expands it. No CGS change
+  needed.
+- **API-key path: NOT yet implemented.** `keys.create` today accepts only
+  `rpc:`/`repo:`/`blob:` (an `include:` scope returns `InvalidScope`). Expanding
+  `include:` at key-create is planned — `docs/design/api-key-permission-sets.md`.
+  Until then, list the concrete `repo:org.hypercerts.…?action=…` scopes
+  explicitly. Do **not** tell a user an API key can take an `include:` scope yet.
+
 **Two authorization axes apply to every key request:**
 
 1. **Scope** — does the key's scope set cover this operation? Outside scope →

--- a/.agents/skills/app-development-with-cgs/SKILL.md
+++ b/.agents/skills/app-development-with-cgs/SKILL.md
@@ -291,19 +291,20 @@ non-RPC method, or an `aud` for a different service.
 
 **Permission sets (`include:`).** The Hypercerts / Certified record types are
 published as permission sets — scope bundles named by one `include:<nsid>` scope:
-`org.hypercerts.permissions.crud` (write on all `org.hypercerts.*` collections)
-and `app.certified.permissions.crud` (write on all `app.certified.*`). Two sets,
+`org.hypercerts.authWrite` (write on all `org.hypercerts.*` collections)
+and `app.certified.authWrite` (write on all `app.certified.*`). Two sets,
 never one: a set may only reference its own namespace authority. Caveats for an
 agent:
 
-- **OAuth path: usable now.** An app reaching CGS via OAuth + service proxying
-  requests `include:<nsid>` as a scope; the user's PDS expands it. No CGS change
-  needed.
-- **API-key path: NOT yet implemented.** `keys.create` today accepts only
-  `rpc:`/`repo:`/`blob:` (an `include:` scope returns `InvalidScope`). Expanding
-  `include:` at key-create is planned — `docs/design/api-key-permission-sets.md`.
-  Until then, list the concrete `repo:org.hypercerts.…?action=…` scopes
-  explicitly. Do **not** tell a user an API key can take an `include:` scope yet.
+- **OAuth path.** An app reaching CGS via OAuth + service proxying requests
+  `include:<nsid>` as a scope; the user's PDS expands it. No CGS change needed.
+- **API-key path.** `keys.create` accepts an `include:<nsid>` scope and expands
+  it to the concrete `repo:` scopes at create time (resolving the published set
+  via Lexicon resolution); the key stores the expanded scopes, not the
+  `include:`. An unresolvable set → `400 InvalidScope`, no key minted. The
+  expansion is a create-time snapshot — re-issue the key to pick up a later
+  change to the set. You may still list concrete `repo:…?action=…` scopes
+  directly instead.
 
 **Two authorization axes apply to every key request:**
 

--- a/.changeset/api-key-permission-sets.md
+++ b/.changeset/api-key-permission-sets.md
@@ -1,0 +1,15 @@
+---
+'group-service': minor
+---
+
+API keys can now be scoped with an **`include:<nsid>` permission-set scope**. `keys.create` resolves the published permission set (via the standard AT Protocol Lexicon resolution chain — `_lexicon` DNS TXT → authority DID → PDS → `com.atproto.lexicon.schema` record) and expands it into the concrete `repo:` / `rpc:` scopes stored on the key, instead of requiring the owner to enumerate every scope by hand.
+
+**Affects:** Client app developers
+
+- **Use it:** pass `scopes: ['include:org.hypercerts.authWrite']` (or any published permission-set NSID) to `app.certified.group.keys.create`. The returned and stored `scopes` are the **expanded** concrete scopes; the `include:` itself is never stored.
+- **Snapshot semantics:** the set is resolved and frozen at key-creation time. A later change to the published set does not affect already-issued keys — re-issue the key to pick it up.
+- **Failure:** an `include:` whose set cannot be resolved (no `_lexicon` record, unresolvable authority, non-https PDS, missing record, or a record that is not a `permission-set`) is rejected with `400 InvalidScope`, naming the scope; no partial key is minted.
+- **Namespace-agnostic:** the resolver resolves any published set via that set's own namespace authority — CGS has no built-in coupling to specific namespaces.
+- Explicitly listing `rpc:` / `repo:` / `blob:` scopes still works exactly as before; `include:` is an additional convenience. Reading records still needs no scope at all (atproto repo records are public).
+
+See `docs/design/api-key-permission-sets.md` (CGS-side) and the [hypercerts-lexicon permission-sets design](https://github.com/hypercerts-org/hypercerts-lexicon/blob/main/docs/design/permission-sets.md) (the sets themselves).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,14 +80,14 @@ feature), add tests for other code to compensate.
 
 ## Coverage Summary
 
-Baseline as of this document (402 tests across 35 files):
+Baseline as of this document (421 tests across 36 files):
 
 | Metric     | Coverage | Threshold |
 | ---------- | -------- | --------- |
-| Statements | 94.16%   | 94        |
-| Branches   | 91.5%    | 91        |
-| Functions  | 92%      | 92        |
-| Lines      | 94.16%   | 94        |
+| Statements | 94.38%   | 94        |
+| Branches   | 91%      | 91        |
+| Functions  | 92.54%   | 92        |
+| Lines      | 94.38%   | 94        |
 
 ### Known gaps (highest impact first)
 

--- a/demo/src/pages/ApiKeys.tsx
+++ b/demo/src/pages/ApiKeys.tsx
@@ -117,6 +117,10 @@ export function ApiKeys() {
   const [repoCollection, setRepoCollection] = useState('')
   const [repoActions, setRepoActions] = useState<RepoAction[]>([])
   const [blobMime, setBlobMime] = useState('')
+  // Permission-set NSID(s) to include, one per line. Each becomes an
+  // `include:<nsid>` scope, which the service resolves and expands into the
+  // set's concrete repo:/rpc: scopes at create time.
+  const [includeNsids, setIncludeNsids] = useState('')
 
   const [minted, setMinted] = useState<CreatedApiKey | null>(null)
   const [keys, setKeys] = useState<ApiKeySummary[]>([])
@@ -159,6 +163,11 @@ export function ApiKeys() {
       ? repoActions.map((a) => `repo:${repoCollection.trim()}?action=${a}`)
       : []),
     ...(blobMime.trim() ? [`blob:${blobMime.trim()}`] : []),
+    ...includeNsids
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((nsid) => `include:${nsid}`),
   ]
 
   const refresh = async () => {
@@ -192,6 +201,7 @@ export function ApiKeys() {
       setMinted(created)
       setTryKey(created.key) // prefill the "use a key" box with the fresh key
       setName('')
+      setIncludeNsids('')
       await refresh()
     } catch (err: any) {
       setError(err.message)
@@ -400,6 +410,20 @@ export function ApiKeys() {
               value={blobMime}
               onChange={(e) => setBlobMime(e.target.value)}
               placeholder="image/* or */*"
+            />
+          </label>
+        </fieldset>
+
+        <fieldset style={{ border: '1px solid #eee', borderRadius: 4, marginBottom: 12 }}>
+          <legend>Permission sets (include:)</legend>
+          <label style={{ display: 'block', fontSize: 14 }}>
+            One published permission-set NSID per line. The service resolves each
+            and expands it into the set's concrete scopes at create time.
+            <textarea
+              style={{ ...inputStyle, width: '100%', minHeight: 48, fontFamily: 'monospace' }}
+              value={includeNsids}
+              onChange={(e) => setIncludeNsids(e.target.value)}
+              placeholder="org.hypercerts.authWrite"
             />
           </label>
         </fieldset>

--- a/docs/design/api-key-permission-sets.md
+++ b/docs/design/api-key-permission-sets.md
@@ -1,224 +1,69 @@
-# Design: Permission Sets (`include:` scopes)
+# Design: Permission Sets (`include:` scopes) for CGS API keys
 
 Status: **Proposed** (iteration 2 of API keys — builds on
 [`api-keys.md`](api-keys.md))
 
+> **Scope of this doc.** Permission sets are a general AT Protocol mechanism, and
+> the two sets CGS consumes (`org.hypercerts.permissions.crud`,
+> `app.certified.permissions.crud`) are designed, defined, and published in the
+> **`hypercerts-lexicon`** repo. The canonical design — what a permission set is,
+> the namespace-authority rule, why there are two sets, wildcards, `aud` /
+> `inheritAud`, the Lexicon resolution chain, the set contents — lives there:
+> [hypercerts-lexicon `docs/design/permission-sets.md`](https://github.com/hypercerts-org/hypercerts-lexicon/blob/main/docs/design/permission-sets.md).
+>
+> **This doc covers only the CGS-specific part:** how a CGS **API key** consumes
+> an `include:<nsid>` scope. It does not restate the lexicon doc.
+
 Tracking issues:
 
-- (fill in) — Permission-set / `include:` support for API keys
 - [#26 — API-key framework for all CGS XRPCs](https://github.com/hypercerts-org/certified-group-service/issues/26)
   (iteration 1, the foundation this extends)
 
-## Motivation
+(No dedicated tracking issue for `include:` support yet; this doc is the
+current record. Add one here when filed.)
+
+## Context
 
 Iteration 1 ([`api-keys.md`](api-keys.md)) lets an owner mint an API key with an
 explicit list of `rpc:` / `repo:` / `blob:` scopes. That is precise but verbose:
-a backend that does CRUD over a family of record collections must enumerate
-every `repo:<collection>?action=…` scope by hand. The list is easy to get wrong
-and has to be re-derived by every integrator from scratch.
+a backend that does CRUD over a family of record collections must enumerate every
+`repo:<collection>?action=…` scope by hand. A **permission set** collapses that
+to one `include:<nsid>` scope (see the lexicon doc above for the full rationale).
 
-The AT Protocol permission spec already names the fix:
-[**permission sets**](https://atproto.com/specs/permission#permission-sets) — a
-named, published, reusable bundle of scopes, referenced with a single
-`include:<nsid>` scope. The iteration-1 design explicitly deferred this, flagging
-`IncludeScope` as "the 'permission set' (named bundle) primitive, _for later_"
-([`api-keys.md`](api-keys.md), "Can we reuse the AT Protocol permission spec?").
-This document is that "later".
-
-## A permission set is a shared, published artifact — two consumers
-
-The central framing. A permission set is **not** a CGS-specific object. Per the
-spec it is _"published publicly and can be used by any client developer"_, and
-_"Authorization Servers resolve, authenticate, and process permission-sets
-dynamically."_ The same published set serves two consumers:
-
-1. **OAuth clients** — a client requests `include:<nsid>` as an OAuth scope; the
-   user's PDS (the Authorization Server) resolves the set and expands it into the
-   underlying scopes in the grant. This is the **primary** use case: CGS is used
-   as a standard OAuth resource in production, reached via AT Protocol service
-   proxying, and a client integrating with the Certified / Hypercerts record
-   types wants one named scope rather than a hand-written list.
-2. **CGS API-key creation** — when `keys.create` receives an `include:<nsid>`
-   scope, CGS resolves the **same** published set and expands it to concrete
-   scopes stored on the key.
-
-So the **published Lexicon record is the single source of truth**. If CGS keeps
-a local copy of a set for fast resolution, that is an implementation cache, not a
-separate kind of object — it must match what is published.
-
-> **Publication is handled out-of-band.** Publishing the sets (DNS `_lexicon`
-> TXT → authority DID → `com.atproto.lexicon.schema` records) is owned by the
-> namespace operators and is **not** in scope for this document. It is known to
-> be possible (the spec defines the mechanism; see _Resolution_ below). This
-> design only needs to assume a published set is resolvable.
-
-## Which sets, and where they live
-
-A permission set may only contain permissions under its **own** namespace
-authority — spec, verbatim: _"Permission sets are limited to expressing
-permissions that reference resources under the same NSID namespace as the set
-itself."_ It applies uniformly to `repo:` (by collection NSID) and `rpc:` (by lxm
-NSID). So a set lives under, and is authored/published by, the authority of the
-namespace it grants.
-
-The sets we actually need are **record-collection CRUD** bundles — the genuine
-"a backend needs create/update/delete over all of these collections" case. Two,
-both `repo:` sets, both authored and published from the **`hypercerts-lexicon`**
-repo (which is the authority for both namespaces):
-
-| Set (suggested NSID)              | Grants CRUD on                            | Authored in          |
-| --------------------------------- | ----------------------------------------- | -------------------- |
-| `org.hypercerts.permissions.crud` | all `org.hypercerts.*` record collections | `hypercerts-lexicon` |
-| `app.certified.permissions.crud`  | all `app.certified.*` record collections  | `hypercerts-lexicon` |
-
-Both are to be tracked by one issue in that repo (to be filed there, with the
-full enumerated collection lists, after this design lands).
-
-### No CGS service-method set (initially)
-
-CGS's own service methods (`app.certified.group.*` / `app.certified.groups.*`)
-are `rpc:` resources. We considered a CGS-method set (e.g. bundling `member.list`
-together with `audit.query`) and **rejected it**: those methods are
-_fundamentally different_ permissions with no use case that wants exactly them
-together — grouping them would bundle by grammar ("they're all reads"), not by
-what any client needs. A set earns its place only when a known consumer
-repeatedly needs a specific multi-scope bundle; absent that, clients request the
-individual `rpc:` scopes they need. If such a use case appears, a CGS-method set
-can be added later (under CGS's own `app.certified.group.*` authority, which this
-repo controls).
-
-## Background: how `@atproto/oauth-scopes` models a permission set
-
-Verified against `@atproto/oauth-scopes@0.5.0` (the version CGS pins). Two types
-plus one class do the work:
-
-```ts
-// lib/lexicon.d.ts
-type LexiconPermission<P extends string = string> = {
-  readonly type: 'permission'
-  readonly resource: P // 'repo' | 'rpc' | …
-  readonly [x: string]: undefined | ParamValue | readonly ParamValue[]
-}
-type LexiconPermissionSet = {
-  readonly type: 'permission-set'
-  readonly permissions: readonly LexiconPermission<string>[]
-  readonly title?: string
-  readonly detail?: string
-  // + title:lang / detail:lang localisation maps
-}
-
-// scopes/include-scope.d.ts
-class IncludeScope {
-  readonly nsid: Nsid
-  readonly aud: undefined | AtprotoDidRefAbsolute
-  static fromString(scope: string): IncludeScope | null // parses "include:<nsid>[?aud=…]"
-  toScopes(set: LexiconPermissionSet): Array<ScopeStringFor<'repo' | 'rpc'>>
-  toPermissions(set: LexiconPermissionSet): Array<RepoPermission | RpcPermission>
-  isParentAuthorityOf(otherNsid: '*' | Nsid): boolean
-}
-```
-
-The critical guardrail is **namespace authority**: `IncludeScope` only pulls
-permissions whose NSID is under the authority of the set's own NSID
-(`isParentAuthorityOf` / its internal `isAllowedPermission`). A set under
-`org.hypercerts.*` can grant `repo:org.hypercerts.*` but cannot smuggle in a
-foreign-authority permission. This is what makes resolving a remote, third-party
-set safe.
-
-### Collections are enumerated, never wildcarded
-
-A `repo:` permission inside a set names collections by **exact NSID**. The spec,
-verbatim: _"Wildcards are not supported in permissions within a permission set."_
-So a CRUD set cannot say "all `org.hypercerts.*` collections" — it **enumerates**
-each one. The enumerated list _is_ the grant and the security boundary; a new
-collection is uncovered until it is added to the set and re-published.
-
-## `aud` and `inheritAud`
-
-An `rpc:` scope authorizes "call method _lxm_ at audience _aud_" — `aud` names
-**which service**. A `repo:` scope has **no** `aud` (it targets the user's own
-repo).
-
-- For an **OAuth client**, `aud` is load-bearing: the grant lives on the user's
-  PDS, which proxies to many services, so the scope must say which service it
-  authorizes. The client supplies `aud` on the `include:` (`include:<nsid>?aud=…`)
-  and, per spec, _"the `aud` parameter on the `include` will be passed down to
-  those specific `rpc` permissions"_ marked `inheritAud: true`.
-- For a **CGS API key**, `aud` is redundant — a key is only ever presented to
-  CGS — but the `@atproto/oauth-scopes` grammar still requires an `aud` on a
-  parsed `rpc:` scope. So CGS stamps its own service ref as a formality.
-
-`inheritAud` keeps a published set **deployment-agnostic**: the set file hard-codes
-no service DID; whoever invokes the `include:` supplies the concrete `aud`. The
-two CRUD sets are `repo:`-only, so this is moot for them — but it is the reason a
-future `rpc:` set would use `inheritAud` rather than baking in CGS's DID.
+CGS is **one consumer** of these published sets. The other — the primary one — is
+an ordinary OAuth client, whose `include:` scope is resolved and expanded by the
+**user's PDS** during the OAuth grant; that path needs nothing from CGS and is
+covered by the lexicon doc and the [integration guide](../integration-guide.md).
+The rest of this document is purely about the **API-key** path.
 
 ## Decision: CGS expands `include:` at key-create time
 
-For the **CGS API-key** consumer, an `include:` scope is a **create-time
-convenience**, not a stored credential form. When `keys.create` receives
-`include:<nsid>`:
+When `keys.create` receives an `include:<nsid>` scope, CGS resolves the published
+set and expands it to concrete `repo:`/`rpc:` scopes **stored on the key** —
+once, at creation. The key row stores only concrete scopes, exactly as
+iteration 1; the verifier and authz gate (`assertCanWithAudit`, `repoScopesCover`)
+are **unchanged** — they never see an `include:`.
 
-1. resolve the published `LexiconPermissionSet` for the NSID,
-2. call `includeScope.toScopes(set)` to get concrete `repo:`/`rpc:` strings,
-3. run those through the **existing** `canonicalizeScopes` and store the result.
-
-The key row stores only concrete scopes, exactly as iteration 1. The verifier and
-the authz gate (`assertCanWithAudit`, `repoScopesCover`) are **unchanged** — they
-never see an `include:`.
-
-### Why create-time, not request-time
+Why create-time, not request-time:
 
 - **Zero change downstream.** Storage, verifier, and gate already operate on
   concrete scopes; expansion stays inside the create path.
-- **No live dependency on a remote set at request time** (the hot path). A key
+- **No live dependency on a remote set at request time** (the hot path) — a key
   keeps working even if the set's PDS is later unreachable.
 
-### Trade-off
+**Trade-off:** create-time expansion **freezes** the set into the key — if the
+published set later changes, keys already minted keep the old expansion until
+re-issued. An `include:`-minted key is a snapshot, not a live subscription. (This
+is a CGS-API-key property; the OAuth consumer has no such freeze — the user's PDS
+expands per grant.) Note this in the user-facing API docs.
 
-Expanding at create time **freezes** the set into the key: if a set later
-changes, keys already minted keep the old expansion until re-issued. Intentional;
-must be stated in the user-facing API docs — an `include:`-minted key is a
-snapshot, not a live subscription. (The OAuth consumer has no such freeze — the
-AS expands per grant.)
+## Status: not yet implemented
 
-## Resolution
-
-Both consumers resolve a published set via the standard **Lexicon resolution
-system** (the permission spec defers to it; chain verified against
-[`/specs/lexicon`](https://atproto.com/specs/lexicon), core protocol, not
-experimental):
-
-1. **NSID → authority DID via DNS.** Reverse the NSID's authority portion (all
-   but the final name), prepend `_lexicon.`, query that domain for a `TXT` record
-   `did=<DID>`.
-2. **DID → PDS endpoint** via `ctx.idResolver` (`@atproto/identity`, PLC-cached —
-   already used in `src/auth/verifier.ts`, `src/api/group/import.ts`).
-3. **Fetch the schema record**: `com.atproto.repo.getRecord` with
-   `repo=<authority-DID>`, `collection=com.atproto.lexicon.schema`,
-   `rkey=<full-NSID>` (the rkey **is** the NSID).
-4. Validate the record's `main` def is `type: 'permission-set'` and hand it to
-   `IncludeScope.toScopes` — whose authority check guarantees the set can only
-   widen access to its own namespace.
-
-For the **OAuth** consumer the user's PDS does this. For the **CGS API-key**
-consumer CGS does it at `keys.create`.
-
-> **The DNS step is the one new piece for CGS.** `@atproto/identity`'s
-> `IdResolver` handles handle/DID/DID-doc resolution but **not** `_lexicon.`
-> NSID-authority TXT lookups; a follow-up adds that resolver plus a spec-compliant
-> cache (the spec recommends a **~24h stale lifetime**, and warns _not_ to
-> long-cache the DNS step). Until that lands, CGS API keys that reference a set
-> are rejected at create with a clear error; a backend still lists its concrete
-> `repo:org.hypercerts.<x>?action=…` scopes explicitly (exactly as iteration-1
-> keys do). The OAuth consumer is unaffected — the PDS already resolves sets.
-
-### Failure semantics (CGS key-create)
-
-- Resolution happens **once, at key-create time**, never per request.
-- A create that references an unresolvable or non-permission-set NSID **fails**
-  with a clear error (`InvalidScope` / a new `UnresolvablePermissionSet`), rather
-  than minting a partial key.
+`keys.create` today accepts only `rpc:`/`repo:`/`blob:`; `canonicalizeScope`
+returns `InvalidScope` for an `include:` scope (`src/auth/scopes.ts`). Until the
+work below lands, an API key needing Hypercerts/Certified write access must list
+the concrete `repo:<collection>?action=…` scopes explicitly. The OAuth path is
+unaffected — the user's PDS already resolves sets.
 
 ## Wiring it into `keys.create`
 
@@ -246,15 +91,10 @@ Contained in the scope layer + create handler:
    `rpc:`/`repo:`/`blob:` — `include:` must be expanded away _before_ it reaches
    them, so they need no new branch (they only ever see concrete scopes).
 
-   > **Confirm at implementation:** that `IncludeScope.toScopes` applies an
-   > invocation `aud` to `inheritAud` permissions outside a full OAuth grant. If
-   > not, construct the expanded `rpc:` strings with
-   > `RpcPermission.scopeNeededFor({lxm, aud})` directly. (Moot for the two `repo:`
-   > CRUD sets, which carry no `aud`.)
-
 2. **`src/api/keys/create.ts`** — call the expansion step before
    `canonicalizeScopes` (handler is already async). Surface resolution failures
-   as a 400.
+   as a 400 (`InvalidScope` / a new `UnresolvablePermissionSet`); never mint a
+   partial key.
 
 3. **`src/context.ts` / boot** — wire the set resolver (and its cache) onto
    `AppContext`.
@@ -266,23 +106,27 @@ No change to: the `group_api_keys` schema, the verifier, the authz gate, or the
 RBAC role check. Expanded scopes are stored and enforced exactly as iteration-1
 scopes are.
 
-## Worked examples
+### Resolving the set from CGS
 
-### As an OAuth scope (primary)
+CGS resolves a published set via the standard Lexicon resolution chain (defined
+in the lexicon doc): NSID → `_lexicon.` DNS TXT → authority DID → PDS →
+`com.atproto.lexicon.schema` record → validate `permission-set` →
+`IncludeScope.toScopes`.
 
-A client integrating with the Hypercerts record types requests one scope in its
-OAuth authorization:
+> **The DNS step is the one new piece CGS needs.** `@atproto/identity`'s
+> `IdResolver` (already used in `src/auth/verifier.ts`, `src/api/group/import.ts`)
+> handles handle/DID/DID-doc resolution but **not** `_lexicon.` NSID-authority TXT
+> lookups. A follow-up adds that resolver plus a spec-compliant cache (the spec
+> recommends a ~24h stale lifetime and warns not to long-cache the DNS step).
+> Mechanism is confirmed — it is build work, not an unknown.
 
-```
-include:org.hypercerts.permissions.crud
-```
+> **Confirm at implementation:** that `IncludeScope.toScopes` applies an
+> invocation `aud` to `inheritAud` permissions outside a full OAuth grant. If not,
+> construct the expanded `rpc:` strings with
+> `RpcPermission.scopeNeededFor({lxm, aud})` directly. (Moot for the two `repo:`
+> CRUD sets, which carry no `aud`.)
 
-The user's PDS resolves the published set and expands it to one
-`repo:<collection>?action=create&action=update&action=delete` scope **per
-enumerated collection**, granting CRUD on those collections in the user's own
-repo. (No `?aud=` — `repo:` scopes have no audience.)
-
-### As a CGS API-key scope
+## Worked example (API-key path)
 
 ```
 POST app.certified.group.keys.create
@@ -290,7 +134,7 @@ POST app.certified.group.keys.create
   "scopes": ["include:org.hypercerts.permissions.crud"] }
 ```
 
-CGS resolves the same set and expands it; the returned `scopes` array shows the
+CGS resolves the set and expands it; the returned `scopes` array is the
 **expanded** snapshot the key carries:
 
 ```jsonc
@@ -299,7 +143,6 @@ CGS resolves the same set and expands it; the returned `scopes` array shows the
   "key": "…", // once
   "scopes": [
     "repo:org.hypercerts.claim.activity?action=create&action=update&action=delete",
-    "repo:org.hypercerts.claim.contribution?action=create&action=update&action=delete",
     "…one per org.hypercerts.* collection…",
   ],
   "createdAt": "…",
@@ -308,77 +151,44 @@ CGS resolves the same set and expands it; the returned `scopes` array shows the
 
 The key then calls CGS's own write methods —
 `app.certified.group.repo.createRecord` / `putRecord` / `deleteRecord` (which
-proxy to the group's PDS) — with `{ repo: "<group>", collection:
-"org.hypercerts.claim.activity", record: {…} }`. The gate matches the request's
-`collection` against the `repo:` scopes and permits it, denying any unlisted
-collection. For blob upload the caller adds an explicit `blob:` scope (it cannot
-ride in a set — see non-goals).
+proxy to the group's PDS) — with `{ repo, collection, record }`. The gate matches
+the request's `collection` against the key's `repo:` scopes and permits it,
+denying any unlisted collection. Blob upload needs an explicit `blob:` scope
+alongside any `include:` (the permission-set form carries no blob accepts).
 
-## Non-goals (this iteration)
+## CGS-specific: the key-accessible surface caps what any set can grant
 
-- **`blob:` via include.** `IncludeScope.toScopes()` emits only `repo:`/`rpc:`
-  permissions; the permission-set form carries no blob accepts. A key needing
-  blob upload passes an explicit `blob:` scope alongside any `include:`.
-- **Authoring/publishing the sets.** Owned by the namespace operators
-  (`hypercerts-lexicon`), tracked by a separate issue. This repo only _consumes_
-  sets.
-- **Re-expanding issued keys when a set changes.** We expand at create time; an
-  `include:`-minted key is a snapshot.
-- **A CGS service-method (`rpc:`) set.** No current use case (see above).
-
-## The key-accessible surface — what any set can and cannot grant
-
-Regardless of which set or scopes a key holds, its reachable operations are
-**floor-capped by CGS code**, not by the permission set: the authz gate
-(`src/api/util.ts`) only ever consults a scope for ops present in
-`OPERATION_LXM` / `OPERATION_REPO_ACTION` (`src/auth/scopes.ts`); any op absent
-from both maps is denied to a key caller **regardless of scopes**. Today that
-surface is exactly: `member.list`, `audit.query` (rpc), the `repo:` write actions
-(create/update/delete), and `uploadBlob` (blob).
+This is the one substantive CGS constraint not in the lexicon doc. Regardless of
+which set or scopes a key holds, a key's reachable operations are **floor-capped
+by CGS code**: the authz gate (`src/api/util.ts`) only consults a scope for ops
+present in `OPERATION_LXM` / `OPERATION_REPO_ACTION` (`src/auth/scopes.ts`); any
+op absent from both is denied to a key caller **regardless of scopes**. Today
+that surface is exactly: `member.list`, `audit.query` (rpc), the `repo:` write
+actions, and `uploadBlob` (blob).
 
 Consequently **no scope or set** can grant key administration (`keys.create`,
 `keys.delete`) or membership administration (`member.add`, `member.remove`,
-`role.set`). These are deliberately not key-accessible (iteration-1 design; see
-the `keys.create` handler comment "a key cannot mint keys"). This bounds the
-blast radius of any key, however broadly scoped: it cannot escalate by minting
-more keys nor alter the member roster. (This floor-cap applies to the CGS
-API-key consumer; an OAuth grant's reach is governed by the user's PDS plus
-whatever CGS's gate enforces on the proxied call.)
+`role.set`) — deliberately not key-accessible (iteration-1 design; see the
+`keys.create` handler comment "a key cannot mint keys"). An `include:`-minted key
+is bounded by this just like an explicitly-scoped one: it cannot escalate by
+minting more keys nor alter the member roster.
 
-## On parameterization
-
-A set cannot be parameterized by group/repo. Verified against the spec and
-`@atproto/oauth-scopes@0.5.0`: the only parameter `include:` passes down is `aud`
-(via `inheritAud`). `RpcPermission` carries `{lxm, aud}`, `RepoPermission`
-carries `{collection, action}` — no DID/repo axis on either. For CGS API keys
-this is irrelevant anyway: a key is bound to one group by **storage** (minted
-against the request's `repo`, stored in that group's per-group DB, only resolved
-under that group — there is no cross-group key), not by any scope. Group and
-scope set are orthogonal axes.
+Also CGS-specific: a key is bound to **one group** by storage (minted against the
+request's `repo`, stored in that group's per-group DB, only resolved under that
+group — no cross-group key), independent of its scopes. Group and scope set are
+orthogonal axes; a permission set carries no group/repo parameter (none exists in
+the scope grammar — see the lexicon doc's parameterization note).
 
 ## Open questions
 
-**None block this iteration's CGS work.**
-
-- **DNS-TXT NSID-authority resolver + cache** — the one new piece CGS needs to
-  resolve published sets at key-create time (not provided by
-  `@atproto/identity`). Mechanism is confirmed (see _Resolution_); it is build
-  work, not an unknown. May ship in this iteration or a follow-up.
-
-_Recorded so they are not re-litigated:_
-
-- **Set lineup:** two `repo:` CRUD sets (`org.hypercerts.*`, `app.certified.*`),
-  published from `hypercerts-lexicon`. No CGS-method set.
-- **Wildcards:** forbidden inside a set — collections are enumerated.
-- **`aud`/`inheritAud`:** load-bearing for the OAuth consumer; a formality for
-  the API-key consumer.
+**None block this iteration's CGS work.** The only new build piece is the
+DNS-TXT NSID-authority resolver + cache (above); mechanism is confirmed.
 
 ## Future extensions
 
 - **Request-time expansion** (live set propagation) for CGS keys, if a "key
   follows the set" semantics is ever needed — a separate iteration with a
   gate-side resolver cache.
-- **`blob:` in sets**, if/when the spec carries blob accepts and the library
-  expands them.
-- **A CGS service-method set**, if a concrete consumer needs a recurring bundle
-  of `app.certified.group.*` methods.
+- **A CGS service-method (`rpc:`) set**, if a concrete consumer ever needs a
+  recurring bundle of `app.certified.group.*` methods. (None today — see the
+  lexicon doc on why grouping unrelated methods isn't worthwhile.)

--- a/docs/design/api-key-permission-sets.md
+++ b/docs/design/api-key-permission-sets.md
@@ -28,9 +28,9 @@ This document is that "later".
 ## A permission set is a shared, published artifact — two consumers
 
 The central framing. A permission set is **not** a CGS-specific object. Per the
-spec it is *"published publicly and can be used by any client developer"*, and
-*"Authorization Servers resolve, authenticate, and process permission-sets
-dynamically."* The same published set serves two consumers:
+spec it is _"published publicly and can be used by any client developer"_, and
+_"Authorization Servers resolve, authenticate, and process permission-sets
+dynamically."_ The same published set serves two consumers:
 
 1. **OAuth clients** — a client requests `include:<nsid>` as an OAuth scope; the
    user's PDS (the Authorization Server) resolves the set and expands it into the
@@ -55,9 +55,9 @@ separate kind of object — it must match what is published.
 ## Which sets, and where they live
 
 A permission set may only contain permissions under its **own** namespace
-authority — spec, verbatim: *"Permission sets are limited to expressing
+authority — spec, verbatim: _"Permission sets are limited to expressing
 permissions that reference resources under the same NSID namespace as the set
-itself."* It applies uniformly to `repo:` (by collection NSID) and `rpc:` (by lxm
+itself."_ It applies uniformly to `repo:` (by collection NSID) and `rpc:` (by lxm
 NSID). So a set lives under, and is authored/published by, the authority of the
 namespace it grants.
 
@@ -66,10 +66,10 @@ The sets we actually need are **record-collection CRUD** bundles — the genuine
 both `repo:` sets, both authored and published from the **`hypercerts-lexicon`**
 repo (which is the authority for both namespaces):
 
-| Set (suggested NSID) | Grants CRUD on | Authored in |
-| --- | --- | --- |
+| Set (suggested NSID)              | Grants CRUD on                            | Authored in          |
+| --------------------------------- | ----------------------------------------- | -------------------- |
 | `org.hypercerts.permissions.crud` | all `org.hypercerts.*` record collections | `hypercerts-lexicon` |
-| `app.certified.permissions.crud` | all `app.certified.*` record collections | `hypercerts-lexicon` |
+| `app.certified.permissions.crud`  | all `app.certified.*` record collections  | `hypercerts-lexicon` |
 
 Both are to be tracked by one issue in that repo (to be filed there, with the
 full enumerated collection lists, after this design lands).
@@ -78,13 +78,14 @@ full enumerated collection lists, after this design lands).
 
 CGS's own service methods (`app.certified.group.*` / `app.certified.groups.*`)
 are `rpc:` resources. We considered a CGS-method set (e.g. bundling `member.list`
-+ `audit.query`) and **rejected it**: those methods are *fundamentally different*
-permissions with no use case that wants exactly them together — grouping them
-would bundle by grammar ("they're all reads"), not by what any client needs. A
-set earns its place only when a known consumer repeatedly needs a specific
-multi-scope bundle; absent that, clients request the individual `rpc:` scopes
-they need. If such a use case appears, a CGS-method set can be added later (under
-CGS's own `app.certified.group.*` authority, which this repo controls).
+together with `audit.query`) and **rejected it**: those methods are
+_fundamentally different_ permissions with no use case that wants exactly them
+together — grouping them would bundle by grammar ("they're all reads"), not by
+what any client needs. A set earns its place only when a known consumer
+repeatedly needs a specific multi-scope bundle; absent that, clients request the
+individual `rpc:` scopes they need. If such a use case appears, a CGS-method set
+can be added later (under CGS's own `app.certified.group.*` authority, which this
+repo controls).
 
 ## Background: how `@atproto/oauth-scopes` models a permission set
 
@@ -127,22 +128,22 @@ set safe.
 ### Collections are enumerated, never wildcarded
 
 A `repo:` permission inside a set names collections by **exact NSID**. The spec,
-verbatim: *"Wildcards are not supported in permissions within a permission set."*
+verbatim: _"Wildcards are not supported in permissions within a permission set."_
 So a CRUD set cannot say "all `org.hypercerts.*` collections" — it **enumerates**
-each one. The enumerated list *is* the grant and the security boundary; a new
+each one. The enumerated list _is_ the grant and the security boundary; a new
 collection is uncovered until it is added to the set and re-published.
 
 ## `aud` and `inheritAud`
 
-An `rpc:` scope authorizes "call method *lxm* at audience *aud*" — `aud` names
+An `rpc:` scope authorizes "call method _lxm_ at audience _aud_" — `aud` names
 **which service**. A `repo:` scope has **no** `aud` (it targets the user's own
 repo).
 
 - For an **OAuth client**, `aud` is load-bearing: the grant lives on the user's
   PDS, which proxies to many services, so the scope must say which service it
   authorizes. The client supplies `aud` on the `include:` (`include:<nsid>?aud=…`)
-  and, per spec, *"the `aud` parameter on the `include` will be passed down to
-  those specific `rpc` permissions"* marked `inheritAud: true`.
+  and, per spec, _"the `aud` parameter on the `include` will be passed down to
+  those specific `rpc` permissions"_ marked `inheritAud: true`.
 - For a **CGS API key**, `aud` is redundant — a key is only ever presented to
   CGS — but the `@atproto/oauth-scopes` grammar still requires an `aud` on a
   parsed `rpc:` scope. So CGS stamps its own service ref as a formality.
@@ -206,7 +207,7 @@ consumer CGS does it at `keys.create`.
 > **The DNS step is the one new piece for CGS.** `@atproto/identity`'s
 > `IdResolver` handles handle/DID/DID-doc resolution but **not** `_lexicon.`
 > NSID-authority TXT lookups; a follow-up adds that resolver plus a spec-compliant
-> cache (the spec recommends a **~24h stale lifetime**, and warns *not* to
+> cache (the spec recommends a **~24h stale lifetime**, and warns _not_ to
 > long-cache the DNS step). Until that lands, CGS API keys that reference a set
 > are rejected at create with a clear error; a backend still lists its concrete
 > `repo:org.hypercerts.<x>?action=…` scopes explicitly (exactly as iteration-1
@@ -232,14 +233,17 @@ Contained in the scope layer + create handler:
    // expandIncludes(scopes, ctx) -> string[]
    for (const scope of scopes) {
      const inc = IncludeScope.fromString(scope)
-     if (!inc) { out.push(scope); continue }          // not an include: -> pass through
-     const set = await resolvePermissionSet(ctx, inc.nsid)  // Lexicon resolution (cached)
-     out.push(...inc.toScopes(set))                   // authority-checked by the lib
+     if (!inc) {
+       out.push(scope)
+       continue
+     } // not an include: -> pass through
+     const set = await resolvePermissionSet(ctx, inc.nsid) // Lexicon resolution (cached)
+     out.push(...inc.toScopes(set)) // authority-checked by the lib
    }
    ```
 
    `firstInvalidScope` / `canonicalizeScope` currently reject anything that is not
-   `rpc:`/`repo:`/`blob:` — `include:` must be expanded away *before* it reaches
+   `rpc:`/`repo:`/`blob:` — `include:` must be expanded away _before_ it reaches
    them, so they need no new branch (they only ever see concrete scopes).
 
    > **Confirm at implementation:** that `IncludeScope.toScopes` applies an
@@ -292,13 +296,13 @@ CGS resolves the same set and expands it; the returned `scopes` array shows the
 ```jsonc
 {
   "keyRef": "…",
-  "key": "…",                       // once
+  "key": "…", // once
   "scopes": [
     "repo:org.hypercerts.claim.activity?action=create&action=update&action=delete",
     "repo:org.hypercerts.claim.contribution?action=create&action=update&action=delete",
-    "…one per org.hypercerts.* collection…"
+    "…one per org.hypercerts.* collection…",
   ],
-  "createdAt": "…"
+  "createdAt": "…",
 }
 ```
 
@@ -316,7 +320,7 @@ ride in a set — see non-goals).
   permissions; the permission-set form carries no blob accepts. A key needing
   blob upload passes an explicit `blob:` scope alongside any `include:`.
 - **Authoring/publishing the sets.** Owned by the namespace operators
-  (`hypercerts-lexicon`), tracked by a separate issue. This repo only *consumes*
+  (`hypercerts-lexicon`), tracked by a separate issue. This repo only _consumes_
   sets.
 - **Re-expanding issued keys when a set changes.** We expand at create time; an
   `include:`-minted key is a snapshot.

--- a/docs/design/api-key-permission-sets.md
+++ b/docs/design/api-key-permission-sets.md
@@ -119,7 +119,7 @@ in the lexicon doc): NSID → `_lexicon.` DNS TXT → authority DID → PDS →
 > lookups. A follow-up adds that resolver plus a spec-compliant cache (the spec
 > recommends a ~24h stale lifetime and warns not to long-cache the DNS step).
 > Mechanism is confirmed — it is build work, not an unknown.
-
+>
 > **Confirm at implementation:** that `IncludeScope.toScopes` applies an
 > invocation `aud` to `inheritAud` permissions outside a full OAuth grant. If not,
 > construct the expanded `rpc:` strings with
@@ -128,7 +128,7 @@ in the lexicon doc): NSID → `_lexicon.` DNS TXT → authority DID → PDS →
 
 ## Worked example (API-key path)
 
-```
+```text
 POST app.certified.group.keys.create
 { "repo": "<group>", "name": "hypercerts-backend",
   "scopes": ["include:org.hypercerts.permissions.crud"] }

--- a/docs/design/api-key-permission-sets.md
+++ b/docs/design/api-key-permission-sets.md
@@ -1,11 +1,11 @@
 # Design: Permission Sets (`include:` scopes) for CGS API keys
 
-Status: **Proposed** (iteration 2 of API keys — builds on
+Status: **Implemented** (iteration 2 of API keys — builds on
 [`api-keys.md`](api-keys.md))
 
 > **Scope of this doc.** Permission sets are a general AT Protocol mechanism, and
-> the two sets CGS consumes (`org.hypercerts.permissions.crud`,
-> `app.certified.permissions.crud`) are designed, defined, and published in the
+> the two sets CGS consumes (`org.hypercerts.authWrite`,
+> `app.certified.authWrite`) are designed, defined, and published in the
 > **`hypercerts-lexicon`** repo. The canonical design — what a permission set is,
 > the namespace-authority rule, why there are two sets, wildcards, `aud` /
 > `inheritAud`, the Lexicon resolution chain, the set contents — lives there:
@@ -57,13 +57,16 @@ re-issued. An `include:`-minted key is a snapshot, not a live subscription. (Thi
 is a CGS-API-key property; the OAuth consumer has no such freeze — the user's PDS
 expands per grant.) Note this in the user-facing API docs.
 
-## Status: not yet implemented
+## Status: implemented
 
-`keys.create` today accepts only `rpc:`/`repo:`/`blob:`; `canonicalizeScope`
-returns `InvalidScope` for an `include:` scope (`src/auth/scopes.ts`). Until the
-work below lands, an API key needing Hypercerts/Certified write access must list
-the concrete `repo:<collection>?action=…` scopes explicitly. The OAuth path is
-unaffected — the user's PDS already resolves sets.
+`keys.create` accepts an `include:<nsid>` scope and expands it (via
+`expandIncludes` in `src/auth/scopes.ts`, resolving the set with
+`PermissionSetResolver` in `src/auth/permission-set-resolver.js`) into the
+concrete scopes stored on the key. An `include:` whose set cannot be resolved is
+rejected with `400 InvalidScope`, naming the offending scope; no partial key is
+minted. The resolver is **namespace-agnostic** — it resolves any published set
+via that set's own namespace authority, with no built-in knowledge of
+`org.hypercerts.*` / `app.certified.*`.
 
 ## Wiring it into `keys.create`
 
@@ -131,7 +134,7 @@ in the lexicon doc): NSID → `_lexicon.` DNS TXT → authority DID → PDS →
 ```text
 POST app.certified.group.keys.create
 { "repo": "<group>", "name": "hypercerts-backend",
-  "scopes": ["include:org.hypercerts.permissions.crud"] }
+  "scopes": ["include:org.hypercerts.authWrite"] }
 ```
 
 CGS resolves the set and expands it; the returned `scopes` array is the

--- a/docs/design/api-key-permission-sets.md
+++ b/docs/design/api-key-permission-sets.md
@@ -1,0 +1,380 @@
+# Design: Permission Sets (`include:` scopes)
+
+Status: **Proposed** (iteration 2 of API keys — builds on
+[`api-keys.md`](api-keys.md))
+
+Tracking issues:
+
+- (fill in) — Permission-set / `include:` support for API keys
+- [#26 — API-key framework for all CGS XRPCs](https://github.com/hypercerts-org/certified-group-service/issues/26)
+  (iteration 1, the foundation this extends)
+
+## Motivation
+
+Iteration 1 ([`api-keys.md`](api-keys.md)) lets an owner mint an API key with an
+explicit list of `rpc:` / `repo:` / `blob:` scopes. That is precise but verbose:
+a backend that does CRUD over a family of record collections must enumerate
+every `repo:<collection>?action=…` scope by hand. The list is easy to get wrong
+and has to be re-derived by every integrator from scratch.
+
+The AT Protocol permission spec already names the fix:
+[**permission sets**](https://atproto.com/specs/permission#permission-sets) — a
+named, published, reusable bundle of scopes, referenced with a single
+`include:<nsid>` scope. The iteration-1 design explicitly deferred this, flagging
+`IncludeScope` as "the 'permission set' (named bundle) primitive, _for later_"
+([`api-keys.md`](api-keys.md), "Can we reuse the AT Protocol permission spec?").
+This document is that "later".
+
+## A permission set is a shared, published artifact — two consumers
+
+The central framing. A permission set is **not** a CGS-specific object. Per the
+spec it is *"published publicly and can be used by any client developer"*, and
+*"Authorization Servers resolve, authenticate, and process permission-sets
+dynamically."* The same published set serves two consumers:
+
+1. **OAuth clients** — a client requests `include:<nsid>` as an OAuth scope; the
+   user's PDS (the Authorization Server) resolves the set and expands it into the
+   underlying scopes in the grant. This is the **primary** use case: CGS is used
+   as a standard OAuth resource in production, reached via AT Protocol service
+   proxying, and a client integrating with the Certified / Hypercerts record
+   types wants one named scope rather than a hand-written list.
+2. **CGS API-key creation** — when `keys.create` receives an `include:<nsid>`
+   scope, CGS resolves the **same** published set and expands it to concrete
+   scopes stored on the key.
+
+So the **published Lexicon record is the single source of truth**. If CGS keeps
+a local copy of a set for fast resolution, that is an implementation cache, not a
+separate kind of object — it must match what is published.
+
+> **Publication is handled out-of-band.** Publishing the sets (DNS `_lexicon`
+> TXT → authority DID → `com.atproto.lexicon.schema` records) is owned by the
+> namespace operators and is **not** in scope for this document. It is known to
+> be possible (the spec defines the mechanism; see _Resolution_ below). This
+> design only needs to assume a published set is resolvable.
+
+## Which sets, and where they live
+
+A permission set may only contain permissions under its **own** namespace
+authority — spec, verbatim: *"Permission sets are limited to expressing
+permissions that reference resources under the same NSID namespace as the set
+itself."* It applies uniformly to `repo:` (by collection NSID) and `rpc:` (by lxm
+NSID). So a set lives under, and is authored/published by, the authority of the
+namespace it grants.
+
+The sets we actually need are **record-collection CRUD** bundles — the genuine
+"a backend needs create/update/delete over all of these collections" case. Two,
+both `repo:` sets, both authored and published from the **`hypercerts-lexicon`**
+repo (which is the authority for both namespaces):
+
+| Set (suggested NSID) | Grants CRUD on | Authored in |
+| --- | --- | --- |
+| `org.hypercerts.permissions.crud` | all `org.hypercerts.*` record collections | `hypercerts-lexicon` |
+| `app.certified.permissions.crud` | all `app.certified.*` record collections | `hypercerts-lexicon` |
+
+Both are to be tracked by one issue in that repo (to be filed there, with the
+full enumerated collection lists, after this design lands).
+
+### No CGS service-method set (initially)
+
+CGS's own service methods (`app.certified.group.*` / `app.certified.groups.*`)
+are `rpc:` resources. We considered a CGS-method set (e.g. bundling `member.list`
++ `audit.query`) and **rejected it**: those methods are *fundamentally different*
+permissions with no use case that wants exactly them together — grouping them
+would bundle by grammar ("they're all reads"), not by what any client needs. A
+set earns its place only when a known consumer repeatedly needs a specific
+multi-scope bundle; absent that, clients request the individual `rpc:` scopes
+they need. If such a use case appears, a CGS-method set can be added later (under
+CGS's own `app.certified.group.*` authority, which this repo controls).
+
+## Background: how `@atproto/oauth-scopes` models a permission set
+
+Verified against `@atproto/oauth-scopes@0.5.0` (the version CGS pins). Two types
+plus one class do the work:
+
+```ts
+// lib/lexicon.d.ts
+type LexiconPermission<P extends string = string> = {
+  readonly type: 'permission'
+  readonly resource: P // 'repo' | 'rpc' | …
+  readonly [x: string]: undefined | ParamValue | readonly ParamValue[]
+}
+type LexiconPermissionSet = {
+  readonly type: 'permission-set'
+  readonly permissions: readonly LexiconPermission<string>[]
+  readonly title?: string
+  readonly detail?: string
+  // + title:lang / detail:lang localisation maps
+}
+
+// scopes/include-scope.d.ts
+class IncludeScope {
+  readonly nsid: Nsid
+  readonly aud: undefined | AtprotoDidRefAbsolute
+  static fromString(scope: string): IncludeScope | null // parses "include:<nsid>[?aud=…]"
+  toScopes(set: LexiconPermissionSet): Array<ScopeStringFor<'repo' | 'rpc'>>
+  toPermissions(set: LexiconPermissionSet): Array<RepoPermission | RpcPermission>
+  isParentAuthorityOf(otherNsid: '*' | Nsid): boolean
+}
+```
+
+The critical guardrail is **namespace authority**: `IncludeScope` only pulls
+permissions whose NSID is under the authority of the set's own NSID
+(`isParentAuthorityOf` / its internal `isAllowedPermission`). A set under
+`org.hypercerts.*` can grant `repo:org.hypercerts.*` but cannot smuggle in a
+foreign-authority permission. This is what makes resolving a remote, third-party
+set safe.
+
+### Collections are enumerated, never wildcarded
+
+A `repo:` permission inside a set names collections by **exact NSID**. The spec,
+verbatim: *"Wildcards are not supported in permissions within a permission set."*
+So a CRUD set cannot say "all `org.hypercerts.*` collections" — it **enumerates**
+each one. The enumerated list *is* the grant and the security boundary; a new
+collection is uncovered until it is added to the set and re-published.
+
+## `aud` and `inheritAud`
+
+An `rpc:` scope authorizes "call method *lxm* at audience *aud*" — `aud` names
+**which service**. A `repo:` scope has **no** `aud` (it targets the user's own
+repo).
+
+- For an **OAuth client**, `aud` is load-bearing: the grant lives on the user's
+  PDS, which proxies to many services, so the scope must say which service it
+  authorizes. The client supplies `aud` on the `include:` (`include:<nsid>?aud=…`)
+  and, per spec, *"the `aud` parameter on the `include` will be passed down to
+  those specific `rpc` permissions"* marked `inheritAud: true`.
+- For a **CGS API key**, `aud` is redundant — a key is only ever presented to
+  CGS — but the `@atproto/oauth-scopes` grammar still requires an `aud` on a
+  parsed `rpc:` scope. So CGS stamps its own service ref as a formality.
+
+`inheritAud` keeps a published set **deployment-agnostic**: the set file hard-codes
+no service DID; whoever invokes the `include:` supplies the concrete `aud`. The
+two CRUD sets are `repo:`-only, so this is moot for them — but it is the reason a
+future `rpc:` set would use `inheritAud` rather than baking in CGS's DID.
+
+## Decision: CGS expands `include:` at key-create time
+
+For the **CGS API-key** consumer, an `include:` scope is a **create-time
+convenience**, not a stored credential form. When `keys.create` receives
+`include:<nsid>`:
+
+1. resolve the published `LexiconPermissionSet` for the NSID,
+2. call `includeScope.toScopes(set)` to get concrete `repo:`/`rpc:` strings,
+3. run those through the **existing** `canonicalizeScopes` and store the result.
+
+The key row stores only concrete scopes, exactly as iteration 1. The verifier and
+the authz gate (`assertCanWithAudit`, `repoScopesCover`) are **unchanged** — they
+never see an `include:`.
+
+### Why create-time, not request-time
+
+- **Zero change downstream.** Storage, verifier, and gate already operate on
+  concrete scopes; expansion stays inside the create path.
+- **No live dependency on a remote set at request time** (the hot path). A key
+  keeps working even if the set's PDS is later unreachable.
+
+### Trade-off
+
+Expanding at create time **freezes** the set into the key: if a set later
+changes, keys already minted keep the old expansion until re-issued. Intentional;
+must be stated in the user-facing API docs — an `include:`-minted key is a
+snapshot, not a live subscription. (The OAuth consumer has no such freeze — the
+AS expands per grant.)
+
+## Resolution
+
+Both consumers resolve a published set via the standard **Lexicon resolution
+system** (the permission spec defers to it; chain verified against
+[`/specs/lexicon`](https://atproto.com/specs/lexicon), core protocol, not
+experimental):
+
+1. **NSID → authority DID via DNS.** Reverse the NSID's authority portion (all
+   but the final name), prepend `_lexicon.`, query that domain for a `TXT` record
+   `did=<DID>`.
+2. **DID → PDS endpoint** via `ctx.idResolver` (`@atproto/identity`, PLC-cached —
+   already used in `src/auth/verifier.ts`, `src/api/group/import.ts`).
+3. **Fetch the schema record**: `com.atproto.repo.getRecord` with
+   `repo=<authority-DID>`, `collection=com.atproto.lexicon.schema`,
+   `rkey=<full-NSID>` (the rkey **is** the NSID).
+4. Validate the record's `main` def is `type: 'permission-set'` and hand it to
+   `IncludeScope.toScopes` — whose authority check guarantees the set can only
+   widen access to its own namespace.
+
+For the **OAuth** consumer the user's PDS does this. For the **CGS API-key**
+consumer CGS does it at `keys.create`.
+
+> **The DNS step is the one new piece for CGS.** `@atproto/identity`'s
+> `IdResolver` handles handle/DID/DID-doc resolution but **not** `_lexicon.`
+> NSID-authority TXT lookups; a follow-up adds that resolver plus a spec-compliant
+> cache (the spec recommends a **~24h stale lifetime**, and warns *not* to
+> long-cache the DNS step). Until that lands, CGS API keys that reference a set
+> are rejected at create with a clear error; a backend still lists its concrete
+> `repo:org.hypercerts.<x>?action=…` scopes explicitly (exactly as iteration-1
+> keys do). The OAuth consumer is unaffected — the PDS already resolves sets.
+
+### Failure semantics (CGS key-create)
+
+- Resolution happens **once, at key-create time**, never per request.
+- A create that references an unresolvable or non-permission-set NSID **fails**
+  with a clear error (`InvalidScope` / a new `UnresolvablePermissionSet`), rather
+  than minting a partial key.
+
+## Wiring it into `keys.create`
+
+Contained in the scope layer + create handler:
+
+1. **`src/auth/scopes.ts`** — add a step that runs **before** `canonicalizeScopes`
+   and rewrites the incoming scope list, replacing each `include:` with its
+   expanded `repo:`/`rpc:` scopes; the existing `canonicalizeScopes` then
+   validates/normalises the whole list as today:
+
+   ```ts
+   // expandIncludes(scopes, ctx) -> string[]
+   for (const scope of scopes) {
+     const inc = IncludeScope.fromString(scope)
+     if (!inc) { out.push(scope); continue }          // not an include: -> pass through
+     const set = await resolvePermissionSet(ctx, inc.nsid)  // Lexicon resolution (cached)
+     out.push(...inc.toScopes(set))                   // authority-checked by the lib
+   }
+   ```
+
+   `firstInvalidScope` / `canonicalizeScope` currently reject anything that is not
+   `rpc:`/`repo:`/`blob:` — `include:` must be expanded away *before* it reaches
+   them, so they need no new branch (they only ever see concrete scopes).
+
+   > **Confirm at implementation:** that `IncludeScope.toScopes` applies an
+   > invocation `aud` to `inheritAud` permissions outside a full OAuth grant. If
+   > not, construct the expanded `rpc:` strings with
+   > `RpcPermission.scopeNeededFor({lxm, aud})` directly. (Moot for the two `repo:`
+   > CRUD sets, which carry no `aud`.)
+
+2. **`src/api/keys/create.ts`** — call the expansion step before
+   `canonicalizeScopes` (handler is already async). Surface resolution failures
+   as a 400.
+
+3. **`src/context.ts` / boot** — wire the set resolver (and its cache) onto
+   `AppContext`.
+
+4. **Lexicon `keys.create` input doc** — broaden the `scopes` description to
+   mention the `include:` form; no schema change (still `string[]`).
+
+No change to: the `group_api_keys` schema, the verifier, the authz gate, or the
+RBAC role check. Expanded scopes are stored and enforced exactly as iteration-1
+scopes are.
+
+## Worked examples
+
+### As an OAuth scope (primary)
+
+A client integrating with the Hypercerts record types requests one scope in its
+OAuth authorization:
+
+```
+include:org.hypercerts.permissions.crud
+```
+
+The user's PDS resolves the published set and expands it to one
+`repo:<collection>?action=create&action=update&action=delete` scope **per
+enumerated collection**, granting CRUD on those collections in the user's own
+repo. (No `?aud=` — `repo:` scopes have no audience.)
+
+### As a CGS API-key scope
+
+```
+POST app.certified.group.keys.create
+{ "repo": "<group>", "name": "hypercerts-backend",
+  "scopes": ["include:org.hypercerts.permissions.crud"] }
+```
+
+CGS resolves the same set and expands it; the returned `scopes` array shows the
+**expanded** snapshot the key carries:
+
+```jsonc
+{
+  "keyRef": "…",
+  "key": "…",                       // once
+  "scopes": [
+    "repo:org.hypercerts.claim.activity?action=create&action=update&action=delete",
+    "repo:org.hypercerts.claim.contribution?action=create&action=update&action=delete",
+    "…one per org.hypercerts.* collection…"
+  ],
+  "createdAt": "…"
+}
+```
+
+The key then calls CGS's own write methods —
+`app.certified.group.repo.createRecord` / `putRecord` / `deleteRecord` (which
+proxy to the group's PDS) — with `{ repo: "<group>", collection:
+"org.hypercerts.claim.activity", record: {…} }`. The gate matches the request's
+`collection` against the `repo:` scopes and permits it, denying any unlisted
+collection. For blob upload the caller adds an explicit `blob:` scope (it cannot
+ride in a set — see non-goals).
+
+## Non-goals (this iteration)
+
+- **`blob:` via include.** `IncludeScope.toScopes()` emits only `repo:`/`rpc:`
+  permissions; the permission-set form carries no blob accepts. A key needing
+  blob upload passes an explicit `blob:` scope alongside any `include:`.
+- **Authoring/publishing the sets.** Owned by the namespace operators
+  (`hypercerts-lexicon`), tracked by a separate issue. This repo only *consumes*
+  sets.
+- **Re-expanding issued keys when a set changes.** We expand at create time; an
+  `include:`-minted key is a snapshot.
+- **A CGS service-method (`rpc:`) set.** No current use case (see above).
+
+## The key-accessible surface — what any set can and cannot grant
+
+Regardless of which set or scopes a key holds, its reachable operations are
+**floor-capped by CGS code**, not by the permission set: the authz gate
+(`src/api/util.ts`) only ever consults a scope for ops present in
+`OPERATION_LXM` / `OPERATION_REPO_ACTION` (`src/auth/scopes.ts`); any op absent
+from both maps is denied to a key caller **regardless of scopes**. Today that
+surface is exactly: `member.list`, `audit.query` (rpc), the `repo:` write actions
+(create/update/delete), and `uploadBlob` (blob).
+
+Consequently **no scope or set** can grant key administration (`keys.create`,
+`keys.delete`) or membership administration (`member.add`, `member.remove`,
+`role.set`). These are deliberately not key-accessible (iteration-1 design; see
+the `keys.create` handler comment "a key cannot mint keys"). This bounds the
+blast radius of any key, however broadly scoped: it cannot escalate by minting
+more keys nor alter the member roster. (This floor-cap applies to the CGS
+API-key consumer; an OAuth grant's reach is governed by the user's PDS plus
+whatever CGS's gate enforces on the proxied call.)
+
+## On parameterization
+
+A set cannot be parameterized by group/repo. Verified against the spec and
+`@atproto/oauth-scopes@0.5.0`: the only parameter `include:` passes down is `aud`
+(via `inheritAud`). `RpcPermission` carries `{lxm, aud}`, `RepoPermission`
+carries `{collection, action}` — no DID/repo axis on either. For CGS API keys
+this is irrelevant anyway: a key is bound to one group by **storage** (minted
+against the request's `repo`, stored in that group's per-group DB, only resolved
+under that group — there is no cross-group key), not by any scope. Group and
+scope set are orthogonal axes.
+
+## Open questions
+
+**None block this iteration's CGS work.**
+
+- **DNS-TXT NSID-authority resolver + cache** — the one new piece CGS needs to
+  resolve published sets at key-create time (not provided by
+  `@atproto/identity`). Mechanism is confirmed (see _Resolution_); it is build
+  work, not an unknown. May ship in this iteration or a follow-up.
+
+_Recorded so they are not re-litigated:_
+
+- **Set lineup:** two `repo:` CRUD sets (`org.hypercerts.*`, `app.certified.*`),
+  published from `hypercerts-lexicon`. No CGS-method set.
+- **Wildcards:** forbidden inside a set — collections are enumerated.
+- **`aud`/`inheritAud`:** load-bearing for the OAuth consumer; a formality for
+  the API-key consumer.
+
+## Future extensions
+
+- **Request-time expansion** (live set propagation) for CGS keys, if a "key
+  follows the set" semantics is ever needed — a separate iteration with a
+  gate-side resolver cache.
+- **`blob:` in sets**, if/when the spec carries blob accepts and the library
+  expands them.
+- **A CGS service-method set**, if a concrete consumer needs a recurring bundle
+  of `app.certified.group.*` methods.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -734,29 +734,36 @@ A `repo:` scope picks the collection + action; the issuing owner's **role** stil
 
 Listing every `repo:<collection>?action=…` scope by hand is tedious and easy to get out of date. The Hypercerts and Certified record types are published as **permission sets** — named, reusable scope bundles you reference with a single `include:<nsid>` scope:
 
-| Permission set                    | Grants write (create/update/delete) on    |
-| --------------------------------- | ----------------------------------------- |
-| `org.hypercerts.permissions.crud` | all `org.hypercerts.*` record collections |
-| `app.certified.permissions.crud`  | all `app.certified.*` record collections  |
+| Permission set             | Grants write (create/update/delete) on    |
+| -------------------------- | ----------------------------------------- |
+| `org.hypercerts.authWrite` | all `org.hypercerts.*` record collections |
+| `app.certified.authWrite`  | all `app.certified.*` record collections  |
 
 These are published in the [`hypercerts-lexicon`](https://github.com/hypercerts-org/hypercerts-lexicon) repo (the namespace authority), and are usable in **two** ways:
 
 **1. As an OAuth scope (available now).** If your app reaches CGS through standard AT Protocol OAuth + service proxying, request the set as a scope in your authorization request and the user's PDS expands it for you:
 
 ```text
-scope: include:org.hypercerts.permissions.crud
+scope: include:org.hypercerts.authWrite
 ```
 
 The user sees the set's plain-language description ("Manage your Hypercerts data") on the consent screen. An app that writes both Hypercerts and Certified records requests **both** `include:` scopes — a permission set may only reference its own namespace authority, so the two cannot be combined into one set.
 
-**2. As an API-key scope (planned, not yet available).** The intent is for `keys.create` to accept `include:<nsid>` and expand it to the underlying `repo:` scopes at key-creation time. **This is not implemented yet** (design: `docs/design/api-key-permission-sets.md`). Until it lands, an API key that needs Hypercerts/Certified write access must list the concrete `repo:` scopes explicitly — e.g.:
+**2. As an API-key scope.** `keys.create` accepts an `include:<nsid>` scope and expands it to the underlying `repo:` scopes at key-creation time (design: `docs/design/api-key-permission-sets.md`):
 
 ```typescript
-scopes: [
-  'repo:org.hypercerts.claim.activity?action=create',
-  'repo:org.hypercerts.claim.activity?action=update',
-  // …one per collection + action you need
-]
+await fetch(`${GROUP_SERVICE}/xrpc/app.certified.group.keys.create`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${ownerJwt}` },
+  body: JSON.stringify({
+    repo: groupDid,
+    name: 'hypercerts backend',
+    scopes: ['include:org.hypercerts.authWrite'],
+  }),
+})
+// The returned (and stored) scopes are the EXPANDED concrete repo: scope(s);
+// the include: itself is never stored. The set is resolved and frozen at
+// create time, so re-issue the key to pick up a later change to the set.
 ```
 
-Reading these records never needs a scope (or a permission set) at all — atproto repo records are public.
+If the set can't be resolved, the call fails with `400 InvalidScope` and no key is minted. You can still list concrete `repo:<collection>?action=…` scopes explicitly instead of using `include:`. Reading these records never needs a scope (or a permission set) at all — atproto repo records are public.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -729,3 +729,34 @@ await fetch(`${GROUP_SERVICE}/xrpc/app.certified.group.repo.createRecord?repo=${
 ```
 
 A `repo:` scope picks the collection + action; the issuing owner's **role** still decides whose records may be touched — a member-issued key can only mutate records that member authored (`repo:` scopes have no own-vs-any axis). Storing a narrowly-scoped key is far less sensitive than holding the owner's signing key. See `docs/design/api-keys.md`.
+
+### Permission sets: granting whole namespaces at once
+
+Listing every `repo:<collection>?action=…` scope by hand is tedious and easy to get out of date. The Hypercerts and Certified record types are published as **permission sets** — named, reusable scope bundles you reference with a single `include:<nsid>` scope:
+
+| Permission set                    | Grants write (create/update/delete) on    |
+| --------------------------------- | ----------------------------------------- |
+| `org.hypercerts.permissions.crud` | all `org.hypercerts.*` record collections |
+| `app.certified.permissions.crud`  | all `app.certified.*` record collections  |
+
+These are published in the [`hypercerts-lexicon`](https://github.com/hypercerts-org/hypercerts-lexicon) repo (the namespace authority), and are usable in **two** ways:
+
+**1. As an OAuth scope (available now).** If your app reaches CGS through standard AT Protocol OAuth + service proxying, request the set as a scope in your authorization request and the user's PDS expands it for you:
+
+```text
+scope: include:org.hypercerts.permissions.crud
+```
+
+The user sees the set's plain-language description ("Manage your Hypercerts data") on the consent screen. An app that writes both Hypercerts and Certified records requests **both** `include:` scopes — a permission set may only reference its own namespace authority, so the two cannot be combined into one set.
+
+**2. As an API-key scope (planned, not yet available).** The intent is for `keys.create` to accept `include:<nsid>` and expand it to the underlying `repo:` scopes at key-creation time. **This is not implemented yet** (design: `docs/design/api-key-permission-sets.md`). Until it lands, an API key that needs Hypercerts/Certified write access must list the concrete `repo:` scopes explicitly — e.g.:
+
+```typescript
+scopes: [
+  'repo:org.hypercerts.claim.activity?action=create',
+  'repo:org.hypercerts.claim.activity?action=update',
+  // …one per collection + action you need
+]
+```
+
+Reading these records never needs a scope (or a permission set) at all — atproto repo records are public.

--- a/src/api/keys/create.ts
+++ b/src/api/keys/create.ts
@@ -9,7 +9,7 @@ import {
   sqliteToIso,
 } from '../util.js'
 import { generateApiKey } from '../../auth/api-key.js'
-import { canonicalizeScopes } from '../../auth/scopes.js'
+import { canonicalizeScopes, expandIncludes } from '../../auth/scopes.js'
 
 export default function (server: Server, ctx: AppContext) {
   registerAuthedMethod(server, 'app.certified.group.keys.create', ctx, {
@@ -30,12 +30,26 @@ export default function (server: Server, ctx: AppContext) {
         throw new XRPCError(400, 'At least one scope is required', 'InvalidRequest')
       }
 
+      // Expand any `include:<nsid>` permission-set scopes to the concrete
+      // `rpc:`/`repo:` scopes they bundle (resolved via Lexicon resolution), then
+      // canonicalize. A key stores only concrete scopes — the `include:` is a
+      // create-time convenience and is never persisted. Non-`include:` scopes
+      // pass through untouched.
+      const expanded = await expandIncludes(scopes, ctx.config.serviceDid, ctx.permissionSets)
+      if (!expanded.ok) {
+        throw new XRPCError(
+          400,
+          `Invalid scope: ${expanded.scope} (${expanded.reason})`,
+          'InvalidScope',
+        )
+      }
+
       // Canonicalize to this service's stored form: a key only ever calls the
       // CGS it was minted on, so we append our own scope `aud`. A friendly
       // `rpc:<lxm>` is expanded; an already-canonical scope is accepted only if
       // its `aud` is ours — a foreign service DID or wrong service fragment is
       // rejected rather than stored as a dead grant.
-      const canon = canonicalizeScopes(scopes, ctx.config.serviceDid)
+      const canon = canonicalizeScopes(expanded.scopes, ctx.config.serviceDid)
       if (!canon.ok) {
         throw new XRPCError(400, `Invalid scope: ${canon.scope} (${canon.reason})`, 'InvalidScope')
       }

--- a/src/auth/permission-set-resolver.ts
+++ b/src/auth/permission-set-resolver.ts
@@ -1,0 +1,205 @@
+import { resolveTxt as dnsResolveTxt } from 'node:dns/promises'
+import { AtpAgent } from '@atproto/api'
+import { IdResolver } from '@atproto/identity'
+import { NSID } from '@atproto/syntax'
+import type { LexiconPermissionSet } from '@atproto/oauth-scopes'
+import type { Logger } from 'pino'
+
+/**
+ * Resolves an AT Protocol **permission set** (a `type: "permission-set"` lexicon)
+ * from its NSID, using the standard Lexicon resolution system. CGS needs the set
+ * definition to expand an `include:<nsid>` API-key scope into concrete scopes;
+ * `@atproto/oauth-scopes` models permission sets but does not fetch them — the
+ * caller supplies the `LexiconPermissionSet`.
+ *
+ * This resolver is **namespace-agnostic**: it resolves any published set via its
+ * own namespace authority and has no knowledge of specific namespaces. The chain
+ * (see https://atproto.com/specs/lexicon, Resolution):
+ *
+ *   1. NSID → authority DID, via a DNS `TXT` lookup on `_lexicon.<authority>`
+ *      (value `did=<DID>`). `@atproto/identity` does not do this lookup, so it
+ *      is implemented here.
+ *   2. authority DID → PDS endpoint, via `idResolver`.
+ *   3. fetch `com.atproto.repo.getRecord(repo=<DID>,
+ *      collection=com.atproto.lexicon.schema, rkey=<full NSID>)`.
+ *   4. validate the record's `main` def is `type: "permission-set"`.
+ *
+ * Results are cached with a TTL (the permission spec recommends a long expiry
+ * with a ~24h stale lifetime; the DNS step is deliberately not cached for long,
+ * so the whole resolution is cached as one unit with a modest TTL).
+ */
+
+/** Thrown when an NSID cannot be resolved to a valid permission set. */
+export class PermissionSetResolutionError extends Error {
+  constructor(
+    public readonly nsid: string,
+    public readonly reason: string,
+  ) {
+    super(`Could not resolve permission set ${nsid}: ${reason}`)
+    this.name = 'PermissionSetResolutionError'
+  }
+}
+
+/** Look up TXT records for a name; injectable so tests need no real DNS. */
+export type TxtResolver = (hostname: string) => Promise<string[][]>
+
+/** Fetch a lexicon-schema record from a PDS; injectable for tests. */
+export type SchemaRecordFetcher = (
+  pdsUrl: string,
+  authorityDid: string,
+  nsid: string,
+) => Promise<unknown>
+
+interface CacheEntry {
+  value: LexiconPermissionSet
+  expiresAt: number
+}
+
+/** Default record fetcher: a plain unauthenticated `getRecord` against the PDS. */
+async function defaultFetchSchemaRecord(
+  pdsUrl: string,
+  authorityDid: string,
+  nsid: string,
+): Promise<unknown> {
+  const agent = new AtpAgent({ service: pdsUrl })
+  const res = await agent.com.atproto.repo.getRecord({
+    repo: authorityDid,
+    collection: 'com.atproto.lexicon.schema',
+    rkey: nsid,
+  })
+  return res.data.value
+}
+
+/**
+ * Parse the authority DID out of `_lexicon.<authority>` TXT records. The spec
+ * format is a single record `did=<DID>`. Multiple `did=` records (an ambiguous
+ * authority) are rejected rather than guessed.
+ */
+function didFromTxtRecords(records: string[][]): string | null {
+  // Each record is an array of strings that must be concatenated.
+  const dids = records
+    .map((chunks) => chunks.join(''))
+    .map((s) => s.trim())
+    .filter((s) => s.startsWith('did='))
+    .map((s) => s.slice('did='.length))
+  if (dids.length !== 1) return null
+  return dids[0]
+}
+
+export class PermissionSetResolver {
+  private readonly cache = new Map<string, CacheEntry>()
+
+  constructor(
+    private readonly idResolver: IdResolver,
+    private readonly opts: {
+      /** Cache TTL in ms. */
+      ttlMs?: number
+      txtResolver?: TxtResolver
+      fetchSchemaRecord?: SchemaRecordFetcher
+      now?: () => number
+      logger?: Logger
+    } = {},
+  ) {}
+
+  private get ttlMs(): number {
+    return this.opts.ttlMs ?? 60 * 60 * 1000 // 1 hour
+  }
+
+  private now(): number {
+    // `Date.now` is injectable so tests are deterministic.
+    return this.opts.now ? this.opts.now() : Date.now()
+  }
+
+  /**
+   * Resolve a permission set by NSID. Throws `PermissionSetResolutionError` if
+   * the NSID is malformed, the authority cannot be found, the record is missing,
+   * or it is not a `permission-set`.
+   */
+  async resolve(nsid: string): Promise<LexiconPermissionSet> {
+    const cached = this.cache.get(nsid)
+    if (cached && cached.expiresAt > this.now()) return cached.value
+
+    const set = await this.resolveUncached(nsid)
+    this.cache.set(nsid, { value: set, expiresAt: this.now() + this.ttlMs })
+    return set
+  }
+
+  private async resolveUncached(nsid: string): Promise<LexiconPermissionSet> {
+    let authority: string
+    try {
+      authority = NSID.parse(nsid).authority
+    } catch {
+      throw new PermissionSetResolutionError(nsid, 'not a valid NSID')
+    }
+
+    // 1. NSID authority → DID via `_lexicon.<authority>` TXT.
+    const txtName = `_lexicon.${authority}`
+    let records: string[][]
+    try {
+      const resolveTxt = this.opts.txtResolver ?? dnsResolveTxt
+      records = await resolveTxt(txtName)
+    } catch (err) {
+      throw new PermissionSetResolutionError(
+        nsid,
+        `no _lexicon TXT record at ${txtName} (${err instanceof Error ? err.message : String(err)})`,
+      )
+    }
+    const authorityDid = didFromTxtRecords(records)
+    if (!authorityDid) {
+      throw new PermissionSetResolutionError(
+        nsid,
+        `${txtName} did not yield exactly one did= record`,
+      )
+    }
+
+    // 2. DID → PDS endpoint.
+    let pdsUrl: string | undefined
+    try {
+      pdsUrl = (await this.idResolver.did.resolveAtprotoData(authorityDid)).pds
+    } catch (err) {
+      throw new PermissionSetResolutionError(
+        nsid,
+        `could not resolve authority DID ${authorityDid} (${err instanceof Error ? err.message : String(err)})`,
+      )
+    }
+    if (!pdsUrl || !pdsUrl.startsWith('https://')) {
+      throw new PermissionSetResolutionError(
+        nsid,
+        `authority DID ${authorityDid} has no https PDS endpoint`,
+      )
+    }
+
+    // 3. Fetch the lexicon-schema record (rkey is the NSID itself).
+    const fetchRecord = this.opts.fetchSchemaRecord ?? defaultFetchSchemaRecord
+    let value: unknown
+    try {
+      value = await fetchRecord(pdsUrl, authorityDid, nsid)
+    } catch (err) {
+      throw new PermissionSetResolutionError(
+        nsid,
+        `could not fetch schema record (${err instanceof Error ? err.message : String(err)})`,
+      )
+    }
+
+    // 4. Validate it is a permission-set lexicon and return its main def.
+    return assertPermissionSet(nsid, value)
+  }
+}
+
+/**
+ * Validate that a fetched lexicon-schema record's `main` def is a permission set,
+ * and narrow it to `LexiconPermissionSet`. The record is the lexicon document, so
+ * the permission set is at `defs.main`.
+ */
+function assertPermissionSet(nsid: string, value: unknown): LexiconPermissionSet {
+  const main = (value as { defs?: { main?: unknown } } | null)?.defs?.main as
+    | { type?: unknown; permissions?: unknown }
+    | undefined
+  if (!main || main.type !== 'permission-set') {
+    throw new PermissionSetResolutionError(nsid, 'record main def is not a permission-set')
+  }
+  if (!Array.isArray(main.permissions)) {
+    throw new PermissionSetResolutionError(nsid, 'permission-set has no permissions array')
+  }
+  return main as unknown as LexiconPermissionSet
+}

--- a/src/auth/scopes.ts
+++ b/src/auth/scopes.ts
@@ -1,7 +1,15 @@
-import { ScopesSet, RpcPermission, RepoPermission, BlobPermission } from '@atproto/oauth-scopes'
+import {
+  ScopesSet,
+  RpcPermission,
+  RepoPermission,
+  BlobPermission,
+  IncludeScope,
+} from '@atproto/oauth-scopes'
 import type { RepoAction } from '@atproto/oauth-scopes'
 import type { Operation } from '../rbac/permissions.js'
 import { SERVICE_ID_FRAGMENT } from '../did-document.js'
+import type { PermissionSetResolver } from './permission-set-resolver.js'
+import { PermissionSetResolutionError } from './permission-set-resolver.js'
 
 /**
  * The scope-layer `aud` for CGS's own DID, used by `rpc:` scopes.
@@ -162,9 +170,15 @@ export type ScopeCanonicalization =
  *   verbatim after validation; nothing is appended.
  */
 export function canonicalizeScope(scope: string, serviceDid: string): ScopeCanonicalization {
-  if (scope.startsWith('repo:')) return canonicalizeRepoScope(scope)
-  if (scope.startsWith('blob:')) return canonicalizeBlobScope(scope)
-  if (scope.startsWith('rpc:')) return canonicalizeRpcScope(scope, serviceDid)
+  // A scope's resource kind is its leading token before the first `:` or `?`.
+  // Both separators are valid AT Protocol scope syntax: the positional form
+  // (`repo:<collection>`) and the query form (`repo?collection=a&collection=b`),
+  // the latter emitted by IncludeScope.toScopes when a set lists multiple
+  // collections. Match on the kind, not on a `<kind>:` prefix.
+  const kind = scope.split(/[:?]/, 1)[0]
+  if (kind === 'repo') return canonicalizeRepoScope(scope)
+  if (kind === 'blob') return canonicalizeBlobScope(scope)
+  if (kind === 'rpc') return canonicalizeRpcScope(scope, serviceDid)
   return { ok: false, scope, reason: 'unsupported scope kind (expected rpc:, repo: or blob:)' }
 }
 
@@ -222,6 +236,69 @@ export function canonicalizeScopes(
     const result = canonicalizeScope(scope, serviceDid)
     if (!result.ok) return { ok: false, scope: result.scope, reason: result.reason }
     out.push(result.scope)
+  }
+  return { ok: true, scopes: out }
+}
+
+/** Outcome of expanding `include:` scopes in a client-supplied scope list. */
+export type IncludeExpansion =
+  | { ok: true; scopes: string[] }
+  | { ok: false; scope: string; reason: string }
+
+/**
+ * Expand any `include:<nsid>` permission-set scopes into the concrete `rpc:` /
+ * `repo:` scopes they bundle, leaving non-`include:` scopes untouched. Runs
+ * **before** `canonicalizeScopes`, so the expanded output is validated and
+ * normalised exactly like an explicitly-listed scope.
+ *
+ * For each `include:`, the set is resolved (via the standard Lexicon resolution
+ * system — namespace-agnostic, no built-in knowledge of any namespace) and
+ * expanded with `IncludeScope.toScopes`, whose own namespace-authority check
+ * guarantees the set can only widen access to its own namespace.
+ *
+ * The set's `aud` (for any `inheritAud` `rpc:` permission) is supplied by
+ * re-stamping the `include:` with this service's ref before expansion — the
+ * spec's parameterization path. The two record-collection CRUD sets CGS expects
+ * are `repo:`-only, so this is a no-op for them, but it keeps the path correct
+ * for a future `rpc:` set.
+ *
+ * Resolution failures are surfaced as `{ ok: false }` so the caller can return a
+ * `400` naming the offending scope, rather than minting a partial key.
+ */
+export async function expandIncludes(
+  scopes: string[],
+  serviceDid: string,
+  resolver: PermissionSetResolver,
+): Promise<IncludeExpansion> {
+  const aud = serviceScopeAud(serviceDid)
+  const out: string[] = []
+  for (const scope of scopes) {
+    const inc = IncludeScope.fromString(scope)
+    if (inc === null) {
+      // Not an `include:` — pass through for canonicalizeScopes to validate.
+      out.push(scope)
+      continue
+    }
+    let set
+    try {
+      set = await resolver.resolve(inc.nsid)
+    } catch (err) {
+      const reason =
+        err instanceof PermissionSetResolutionError
+          ? err.reason
+          : err instanceof Error
+            ? err.message
+            : String(err)
+      return { ok: false, scope, reason }
+    }
+    // Re-stamp with our aud so `inheritAud` rpc: permissions inherit it on
+    // expansion (no-op for aud-less repo: permissions).
+    const bound = IncludeScope.fromString(`include:${inc.nsid}?aud=${encodeURIComponent(aud)}`)
+    const expanded = (bound ?? inc).toScopes(set)
+    if (expanded.length === 0) {
+      return { ok: false, scope, reason: 'permission set expanded to no scopes' }
+    }
+    out.push(...expanded)
   }
   return { ok: true, scopes: out }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,6 +5,7 @@ import type { Config } from './config.js'
 import type { GlobalDatabase } from './db/schema.js'
 import type { GroupDbPool } from './db/group-db-pool.js'
 import type { AuthVerifier } from './auth/verifier.js'
+import type { PermissionSetResolver } from './auth/permission-set-resolver.js'
 import type { RbacChecker } from './rbac/check.js'
 import type { PdsAgentPool } from './pds/agent.js'
 import type { AuditLogger } from './audit.js'
@@ -17,6 +18,7 @@ export interface AppContext {
   groupDbs: GroupDbPool
   authVerifier: AuthVerifier
   idResolver: IdResolver
+  permissionSets: PermissionSetResolver
   rbac: RbacChecker
   pdsAgents: PdsAgentPool
   audit: AuditLogger

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { mkdirSync } from 'node:fs'
 import { createGroupServer } from './server.js'
 import { loadConfig } from './config.js'
 import { AuthVerifier } from './auth/verifier.js'
+import { PermissionSetResolver } from './auth/permission-set-resolver.js'
 import { NonceCache } from './auth/nonce.js'
 import { RbacChecker } from './rbac/check.js'
 import { registerXrpcMethods } from './api/index.js'
@@ -71,6 +72,7 @@ async function main() {
     logger,
   )
   const rbac = new RbacChecker()
+  const permissionSets = new PermissionSetResolver(idResolver, { logger })
 
   // Express app
   const app = express()
@@ -88,6 +90,7 @@ async function main() {
     groupDbs,
     authVerifier,
     idResolver,
+    permissionSets,
     rbac,
     pdsAgents,
     audit,

--- a/tests/helpers/mock-server.ts
+++ b/tests/helpers/mock-server.ts
@@ -2,6 +2,7 @@ import type Database from 'better-sqlite3'
 import type { AppContext } from '../../src/context.js'
 import type { Config } from '../../src/config.js'
 import { RbacChecker } from '../../src/rbac/check.js'
+import { PermissionSetResolver } from '../../src/auth/permission-set-resolver.js'
 import type { Role } from '../../src/rbac/permissions.js'
 import { AuditLogger } from '../../src/audit.js'
 import { TestMemberIndex } from '../../src/db/member-index.js'
@@ -96,6 +97,13 @@ export async function createTestContext(overrides?: Partial<AppContext>): Promis
     groupDbs: mockGroupDbs as any,
     authVerifier: mockAuth('did:plc:testuser'),
     idResolver: mockIdResolver(),
+    // No permission sets resolvable by default (DNS lookup rejects); tests that
+    // exercise `include:` override `permissionSets` with stubbed resolution.
+    permissionSets: new PermissionSetResolver(mockIdResolver(), {
+      txtResolver: async () => {
+        throw new Error('no DNS in tests')
+      },
+    }),
     rbac: new RbacChecker(),
     pdsAgents: mockPdsAgents as any,
     audit: new AuditLogger(),

--- a/tests/keys-create.test.ts
+++ b/tests/keys-create.test.ts
@@ -137,4 +137,64 @@ describe('keys.create', () => {
       .send({ name: 'self-mint', scopes: [MEMBER_LIST_SCOPE] })
     expect(res.status).toBe(403)
   })
+
+  it('expands an include:<nsid> permission set into the concrete stored scopes', async () => {
+    await seedMember(groupDb, 'did:plc:testuser', 'owner')
+    // Override the resolver to return a known permission set for the include:.
+    ctx.permissionSets = {
+      resolve: async (nsid: string) => {
+        if (nsid !== 'org.hypercerts.authWrite') throw new Error(`unknown set ${nsid}`)
+        return {
+          type: 'permission-set',
+          permissions: [
+            {
+              type: 'permission',
+              resource: 'repo',
+              collection: ['org.hypercerts.claim.activity', 'org.hypercerts.collection'],
+              action: ['create', 'update', 'delete'],
+            },
+          ],
+        }
+      },
+    } as unknown as AppContext['permissionSets']
+
+    const res = await request(buildApp(ctx))
+      .post('/xrpc/app.certified.group.keys.create')
+      .send({ name: 'hypercerts-backend', scopes: ['include:org.hypercerts.authWrite'] })
+
+    expect(res.status).toBe(200)
+    // The key stores the EXPANDED concrete repo: scope (one combined scope
+    // covering all the set's collections), never the include: itself.
+    expect(res.body.scopes).toHaveLength(1)
+    expect(res.body.scopes[0]).toContain('collection=org.hypercerts.claim.activity')
+    expect(res.body.scopes[0]).toContain('collection=org.hypercerts.collection')
+    const row = await groupDb
+      .selectFrom('group_api_keys')
+      .select('scopes')
+      .where('key_ref', '=', res.body.keyRef)
+      .executeTakeFirst()
+    expect(row!.scopes).not.toContain('include:')
+  })
+
+  it('returns 400 InvalidScope when an include: set cannot be resolved', async () => {
+    await seedMember(groupDb, 'did:plc:testuser', 'owner')
+    ctx.permissionSets = {
+      resolve: async (nsid: string) => {
+        throw new Error(`no _lexicon TXT for ${nsid}`)
+      },
+    } as unknown as AppContext['permissionSets']
+
+    const res = await request(buildApp(ctx))
+      .post('/xrpc/app.certified.group.keys.create')
+      .send({ name: 'bad', scopes: ['include:org.nonexistent.authWrite'] })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('InvalidScope')
+    // No key was minted.
+    const count = await groupDb
+      .selectFrom('group_api_keys')
+      .select(groupDb.fn.countAll().as('n'))
+      .executeTakeFirst()
+    expect(Number(count!.n)).toBe(0)
+  })
 })

--- a/tests/permission-set-resolver.test.ts
+++ b/tests/permission-set-resolver.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for PermissionSetResolver — the Lexicon-resolution chain that turns
+ * an NSID into a LexiconPermissionSet (NSID → _lexicon DNS TXT → authority DID →
+ * PDS → com.atproto.lexicon.schema record). DNS and the record fetch are
+ * injected, so no network is touched.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import {
+  PermissionSetResolver,
+  PermissionSetResolutionError,
+} from '../src/auth/permission-set-resolver.js'
+
+// Mock @atproto/api so the DEFAULT record fetcher (which constructs an AtpAgent
+// and calls getRecord) can be exercised without a real PDS.
+const mockGetRecord = vi.fn()
+vi.mock('@atproto/api', () => ({
+  AtpAgent: class {
+    com = { atproto: { repo: { getRecord: mockGetRecord } } }
+    constructor(_opts: unknown) {}
+  },
+}))
+
+const AUTHORITY_DID = 'did:web:permissions.hypercerts.org'
+const PDS_URL = 'https://pds.example.com'
+const NSID = 'org.hypercerts.authWrite'
+
+const PERMISSION_SET = {
+  lexicon: 1,
+  id: NSID,
+  defs: {
+    main: {
+      type: 'permission-set',
+      title: 'Manage your Hypercerts data',
+      permissions: [
+        {
+          type: 'permission',
+          resource: 'repo',
+          collection: ['org.hypercerts.claim.activity'],
+          action: ['create', 'update', 'delete'],
+        },
+      ],
+    },
+  },
+}
+
+/** A resolver wired with stubbed DNS + record fetch + a fake DID→PDS resolver. */
+function makeResolver(opts: {
+  txt?: string[][]
+  txtThrows?: boolean
+  record?: unknown
+  recordThrows?: boolean
+  pds?: string | undefined
+  pdsThrows?: boolean
+  ttlMs?: number
+  now?: () => number
+}) {
+  const idResolver = {
+    did: {
+      resolveAtprotoData: vi.fn(async () => {
+        if (opts.pdsThrows) throw new Error('DID not found')
+        return { pds: opts.pds ?? PDS_URL }
+      }),
+    },
+  } as any
+  const txtResolver = vi.fn(async () => {
+    if (opts.txtThrows) throw new Error('ENOTFOUND')
+    return opts.txt ?? [[`did=${AUTHORITY_DID}`]]
+  })
+  const fetchSchemaRecord = vi.fn(async () => {
+    if (opts.recordThrows) throw new Error('record not found')
+    return opts.record ?? PERMISSION_SET
+  })
+  const resolver = new PermissionSetResolver(idResolver, {
+    txtResolver,
+    fetchSchemaRecord,
+    ttlMs: opts.ttlMs,
+    now: opts.now,
+  })
+  return { resolver, idResolver, txtResolver, fetchSchemaRecord }
+}
+
+describe('PermissionSetResolver', () => {
+  it('resolves NSID → permission set via the full chain', async () => {
+    const { resolver, txtResolver, idResolver, fetchSchemaRecord } = makeResolver({})
+    const set = await resolver.resolve(NSID)
+
+    expect(set.type).toBe('permission-set')
+    expect(set.permissions).toHaveLength(1)
+    // DNS query is on _lexicon.<authority> (authority = reversed domain).
+    expect(txtResolver).toHaveBeenCalledWith('_lexicon.hypercerts.org')
+    expect(idResolver.did.resolveAtprotoData).toHaveBeenCalledWith(AUTHORITY_DID)
+    // rkey is the full NSID.
+    expect(fetchSchemaRecord).toHaveBeenCalledWith(PDS_URL, AUTHORITY_DID, NSID)
+  })
+
+  it('caches a resolved set (second call does no DNS/fetch)', async () => {
+    const { resolver, txtResolver, fetchSchemaRecord } = makeResolver({
+      ttlMs: 60_000,
+      now: () => 1000,
+    })
+    await resolver.resolve(NSID)
+    await resolver.resolve(NSID)
+    expect(txtResolver).toHaveBeenCalledTimes(1)
+    expect(fetchSchemaRecord).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-resolves after the cache TTL expires', async () => {
+    let t = 1000
+    const { resolver, txtResolver } = makeResolver({ ttlMs: 100, now: () => t })
+    await resolver.resolve(NSID)
+    t += 200 // past TTL
+    await resolver.resolve(NSID)
+    expect(txtResolver).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects a malformed NSID', async () => {
+    const { resolver } = makeResolver({})
+    await expect(resolver.resolve('not-an-nsid')).rejects.toBeInstanceOf(
+      PermissionSetResolutionError,
+    )
+  })
+
+  it('rejects when there is no _lexicon TXT record', async () => {
+    const { resolver } = makeResolver({ txtThrows: true })
+    await expect(resolver.resolve(NSID)).rejects.toThrow(/no _lexicon TXT/)
+  })
+
+  it('rejects ambiguous authority (more than one did= record)', async () => {
+    const { resolver } = makeResolver({
+      txt: [[`did=${AUTHORITY_DID}`], ['did=did:web:other.example']],
+    })
+    await expect(resolver.resolve(NSID)).rejects.toThrow(/exactly one did=/)
+  })
+
+  it('rejects a non-https PDS endpoint', async () => {
+    const { resolver } = makeResolver({ pds: 'http://insecure.example' })
+    await expect(resolver.resolve(NSID)).rejects.toThrow(/no https PDS/)
+  })
+
+  it('rejects a record whose main def is not a permission-set', async () => {
+    const { resolver } = makeResolver({
+      record: { lexicon: 1, id: NSID, defs: { main: { type: 'record' } } },
+    })
+    await expect(resolver.resolve(NSID)).rejects.toThrow(/not a permission-set/)
+  })
+
+  it('rejects a permission-set with no permissions array', async () => {
+    const { resolver } = makeResolver({
+      record: { lexicon: 1, id: NSID, defs: { main: { type: 'permission-set' } } },
+    })
+    await expect(resolver.resolve(NSID)).rejects.toThrow(/no permissions array/)
+  })
+
+  it('surfaces a record-fetch failure as PermissionSetResolutionError', async () => {
+    const { resolver } = makeResolver({ recordThrows: true })
+    await expect(resolver.resolve(NSID)).rejects.toThrow(/could not fetch schema record/)
+  })
+
+  it('rejects when the authority DID cannot be resolved', async () => {
+    const { resolver } = makeResolver({ pdsThrows: true })
+    await expect(resolver.resolve(NSID)).rejects.toThrow(/could not resolve authority DID/)
+  })
+
+  it('the default record fetcher calls getRecord with the right collection + rkey', async () => {
+    // No `fetchSchemaRecord` override → exercises defaultFetchSchemaRecord (which
+    // uses the mocked AtpAgent above).
+    mockGetRecord.mockResolvedValueOnce({ data: { value: PERMISSION_SET } })
+    const idResolver = {
+      did: { resolveAtprotoData: vi.fn(async () => ({ pds: PDS_URL })) },
+    } as any
+    const resolver = new PermissionSetResolver(idResolver, {
+      txtResolver: async () => [[`did=${AUTHORITY_DID}`]],
+    })
+
+    const set = await resolver.resolve(NSID)
+    expect(set.type).toBe('permission-set')
+    expect(mockGetRecord).toHaveBeenCalledWith({
+      repo: AUTHORITY_DID,
+      collection: 'com.atproto.lexicon.schema',
+      rkey: NSID,
+    })
+  })
+})

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -8,12 +8,37 @@ import {
   firstInvalidScope,
   canonicalizeScope,
   canonicalizeScopes,
+  expandIncludes,
   repoActionForOperation,
   repoScopesCover,
   blobScopesCover,
 } from '../src/auth/scopes.js'
+import type { PermissionSetResolver } from '../src/auth/permission-set-resolver.js'
 
 const SERVICE_DID = 'did:web:groups.example.com'
+
+/** A fake resolver: maps NSIDs to permission sets, or throws for unknown ones. */
+function fakeResolver(sets: Record<string, unknown>): PermissionSetResolver {
+  return {
+    resolve: async (nsid: string) => {
+      const set = sets[nsid]
+      if (!set) throw new Error(`unknown set ${nsid}`)
+      return set
+    },
+  } as unknown as PermissionSetResolver
+}
+
+const HYPERCERTS_SET = {
+  type: 'permission-set',
+  permissions: [
+    {
+      type: 'permission',
+      resource: 'repo',
+      collection: ['org.hypercerts.claim.activity', 'org.hypercerts.collection'],
+      action: ['create', 'update', 'delete'],
+    },
+  ],
+}
 // The package URL-encodes `#` as `%23` in the emitted scope string; use its own
 // output as the canonical form rather than hand-writing the encoding.
 const MEMBER_LIST_SCOPE = scopeNeededFor('member.list', SERVICE_DID)!
@@ -243,5 +268,59 @@ describe('canonicalizeScope — blob: scopes', () => {
 
   it('rejects a malformed blob: scope', () => {
     expect(canonicalizeScope('blob:*', SERVICE_DID).ok).toBe(false)
+  })
+})
+
+describe('expandIncludes', () => {
+  const resolver = fakeResolver({ 'org.hypercerts.authWrite': HYPERCERTS_SET })
+
+  it('expands an include: to one combined repo: scope covering all collections', async () => {
+    const res = await expandIncludes(['include:org.hypercerts.authWrite'], SERVICE_DID, resolver)
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    // IncludeScope.toScopes coalesces the collection array into a single scope.
+    expect(res.scopes).toHaveLength(1)
+    expect(res.scopes[0]).toContain('collection=org.hypercerts.claim.activity')
+    expect(res.scopes[0]).toContain('collection=org.hypercerts.collection')
+  })
+
+  it('passes non-include: scopes through untouched', async () => {
+    const res = await expandIncludes(
+      ['rpc:app.certified.group.member.list', 'blob:image/*'],
+      SERVICE_DID,
+      resolver,
+    )
+    expect(res).toEqual({
+      ok: true,
+      scopes: ['rpc:app.certified.group.member.list', 'blob:image/*'],
+    })
+  })
+
+  it('mixes an include: with explicit scopes', async () => {
+    const res = await expandIncludes(
+      ['include:org.hypercerts.authWrite', 'blob:image/*'],
+      SERVICE_DID,
+      resolver,
+    )
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    expect(res.scopes).toContain('blob:image/*')
+    expect(res.scopes.some((s) => s.includes('collection=org.hypercerts.'))).toBe(true)
+  })
+
+  it('returns ok:false naming the include: when the set cannot be resolved', async () => {
+    const res = await expandIncludes(['include:org.unknown.authWrite'], SERVICE_DID, resolver)
+    expect(res.ok).toBe(false)
+    if (res.ok) return
+    expect(res.scope).toBe('include:org.unknown.authWrite')
+    expect(res.reason).toMatch(/unknown set/)
+  })
+
+  it('the expanded scopes pass canonicalizeScopes', async () => {
+    const res = await expandIncludes(['include:org.hypercerts.authWrite'], SERVICE_DID, resolver)
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    const canon = canonicalizeScopes(res.scopes, SERVICE_DID)
+    expect(canon.ok).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

Adds support for **`include:<nsid>` permission-set scopes** to CGS API keys — both the design and the implementation.

`keys.create` now accepts an `include:<nsid>` scope, resolves the published permission set via the standard AT Protocol Lexicon resolution chain, and expands it into the concrete `repo:` / `rpc:` scopes stored on the key — so an owner can grant a whole bundle (e.g. CRUD over all of a namespace's record collections) with one scope instead of enumerating each by hand.

## Design

`docs/design/api-key-permission-sets.md` (status: **Implemented**). It cross-references the canonical, namespace-side design in [hypercerts-lexicon `docs/design/permission-sets.md`](https://github.com/hypercerts-org/hypercerts-lexicon/blob/main/docs/design/permission-sets.md) and covers only the CGS-specific parts: create-time expansion (a snapshot), the wiring, the key-accessible-surface floor-cap, and single-group binding.

## Implementation

- **`src/auth/permission-set-resolver.ts`** — `PermissionSetResolver`: resolves any published permission set from its NSID via `_lexicon` DNS TXT → authority DID → PDS → `com.atproto.lexicon.schema` record → validate `type:"permission-set"`. **Namespace-agnostic** — no built-in coupling to `org.hypercerts.*` / `app.certified.*`. Injectable DNS resolver + record fetcher (so tests need no network) and a TTL cache.
- **`expandIncludes` in `src/auth/scopes.ts`** — detects `include:` scopes (via `@atproto/oauth-scopes` `IncludeScope`), resolves + expands them, passes other scopes through. Wired into `keys.create` before `canonicalizeScopes`; an unresolvable set → `400 InvalidScope`, no partial key minted.
- `canonicalizeScope` now dispatches on the scope's resource kind (split on `:`/`?`), so the combined `repo?collection=a&collection=b` form that `IncludeScope.toScopes` emits for multi-collection sets is accepted.
- `permissionSets` added to `AppContext` (boot + test context).

## Semantics

- **Snapshot:** the set is resolved and frozen at key-creation time; a later change to the published set does not affect already-issued keys (re-issue to pick it up). The OAuth-client path has no such freeze — the user's PDS expands per grant.
- **Floor-cap unchanged:** an `include:`-minted key is bounded by the key-accessible surface like any other — it still cannot reach `keys.create` / member admin.
- Explicit `rpc:`/`repo:`/`blob:` scopes work exactly as before; `include:` is additive.

## Tests / coverage

`PermissionSetResolver` unit tests (full chain, cache/TTL, every failure mode, default fetcher via mocked `AtpAgent`), `expandIncludes` unit tests, and `keys.create` integration tests (include: → expanded stored scopes; unresolvable → 400). **421 tests pass**; coverage 94.38 / 91 / 92.54 / 94.38 (above thresholds; AGENTS.md summary updated). Includes a `minor` changeset; integration guide + app-dev skill updated.

## Related

- Lexicon sets + their design: hypercerts-org/hypercerts-lexicon#222 (`org.hypercerts.authWrite`, `app.certified.authWrite`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)