### PR TITLE
feat(api-keys): allow member self-service keys

### DIFF
--- a/.agents/skills/app-development-with-cgs/SKILL.md
+++ b/.agents/skills/app-development-with-cgs/SKILL.md
@@ -46,7 +46,7 @@ CGS accepts two credential kinds. Pick before you write anything.
   window) and single-use. Almost all app flows use this, via service proxying.
 - **API key** (`X-API-Key: cgsk_…`). For a **backend daemon** that must act
   repeatedly without holding a user's signing key or re-minting a JWT every two
-  minutes — e.g. syncing membership, or a server repairing records. Owner-issued,
+  minutes — e.g. syncing membership, or a server repairing records. Member-issued,
   long-lived, scope-limited. See [API keys](#api-keys-for-backend-daemons) below.
 
 If a human is in the loop and you have their OAuth session, use the JWT path. If
@@ -261,20 +261,22 @@ Use this for "which groups am I in" UI. Details:
 
 ## API keys (for backend daemons)
 
-When a server must act without a user session, an **owner** mints an API key. A
-key is a long-lived bearer credential — store it once, send it as
+When a server must act without a user session, any **group member** can mint an
+API key for themselves. A key is a long-lived bearer credential — store it once, send it as
 `X-API-Key: cgsk_<keyRef>.<secret>` on each request. No `aud`, no nonce, no
 2-minute lifetime. It dies only when revoked.
 
-**Lifecycle (all owner-only, all authenticated with a normal owner JWT — a key
-can never manage keys):**
+**Lifecycle (JWT-authenticated; members manage their own keys, owners can list
+and revoke all keys — a key can never manage keys):**
 
-- `app.certified.group.keys.create` — `{ repo, name, scopes }`. The plaintext
-  `key` is returned **exactly once**; persist it immediately, it's never
-  retrievable again.
-- `app.certified.group.keys.list` — never returns the secret or its hash.
-- `app.certified.group.keys.delete` — soft-revoke by `keyRef`; rejected on next
-  use. Idempotent.
+- `app.certified.group.keys.create` — `{ repo, name, scopes }`. The caller can
+  only request scopes their current role can use (e.g. `audit.query` requires
+  admin). The plaintext `key` is returned **exactly once**; persist it
+  immediately, it's never retrievable again.
+- `app.certified.group.keys.list` — members see their own keys; owners see all.
+  Never returns the secret or its hash.
+- `app.certified.group.keys.delete` — soft-revoke by `keyRef`; members can revoke
+  their own keys, owners can revoke any key. Rejected on next use. Idempotent.
 
 **Scopes** (granted at create time, from `@atproto/oauth-scopes`):
 
@@ -310,7 +312,7 @@ agent:
 
 1. **Scope** — does the key's scope set cover this operation? Outside scope →
    `403`.
-2. **Role** — the key acts on behalf of the **owner that issued it**, narrowed
+2. **Role** — the key acts on behalf of the **member that issued it**, narrowed
    by its scopes. A `repo:` write key has _no own-vs-any axis_: the issuing
    role still decides whose records may be touched (a member-issued key can only
    mutate records that member authored; an admin-issued key can touch any).

--- a/.changeset/member-api-keys.md
+++ b/.changeset/member-api-keys.md
@@ -1,0 +1,7 @@
+---
+'group-service': minor
+---
+
+Allow all group members to create, list, and revoke their own API keys. Owners
+retain group-wide visibility and revocation, while API-key auth itself still
+cannot manage keys.

--- a/demo/README.md
+++ b/demo/README.md
@@ -36,7 +36,7 @@ key's scopes can actually authorize:
 - `repo.createRecord` / `repo.putRecord` / `repo.deleteRecord` — `repo:`-scoped
   writes, proxied to the group's PDS.
 
-Owner-only methods (`keys.*`, `role.set`, `member.add`/`remove`, `group.register`)
+JWT-only management methods (`keys.*`, `role.set`, `member.add`/`remove`, `group.register`)
 carry no key scope and so are omitted; `uploadBlob` is omitted too, as it takes a
 raw binary stream rather than a JSON body (use the **Upload** page for blobs).
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -65,7 +65,7 @@ For the full migration walkthrough (per-method `repo` placement, direct vs proxi
 
 ## Authenticating with an API key
 
-As an alternative to a per-request service-auth JWT, an owner can issue a long-lived **API key** (see [API key management](#api-key-management)). A backend authenticates by sending the key in the `X-API-Key` header instead of `Authorization: Bearer`:
+As an alternative to a per-request service-auth JWT, any group member can issue a long-lived **API key** for themselves (see [API key management](#api-key-management)). A backend authenticates by sending the key in the `X-API-Key` header instead of `Authorization: Bearer`:
 
 ```text
 X-API-Key: cgsk_<keyRef>.<secret>
@@ -665,11 +665,11 @@ curl -X POST https://group-service.example.com/xrpc/app.certified.group.role.set
 
 ## API key management
 
-Owner-only methods for issuing and revoking [API keys](#authenticating-with-an-api-key). All three are authenticated with a normal owner **JWT** (not a key — a key can never manage keys). They target a group the same way as other group-scoped methods (`repo` in the body for the procedures, on the querystring for the `list` query).
+JWT-authenticated methods for issuing and revoking [API keys](#authenticating-with-an-api-key). Any group member can create, list, and revoke their own keys; owners can list and revoke all keys in the group. A member can only create keys with scopes their current role can use; for example, `audit.query` requires admin. A key can never manage keys. These methods target a group the same way as other group-scoped methods (`repo` in the body for the procedures, on the querystring for the `list` query).
 
 ### `POST /xrpc/app.certified.group.keys.create`
 
-Mint a key. Owner-only.
+Mint a key for the authenticated group member.
 
 Request body:
 
@@ -704,11 +704,11 @@ Response — the plaintext `key` is returned **only here**:
 }
 ```
 
-Errors: `Forbidden` (not the owner), `InvalidScope` (a scope that is unparseable, names a non-RPC method, or carries an `aud` for a different service).
+Errors: `Forbidden` (not a group member, using API-key auth, or requesting a scope above the caller's role), `InvalidScope` (a scope that is unparseable, names a non-RPC method, or carries an `aud` for a different service).
 
 ### `GET /xrpc/app.certified.group.keys.list`
 
-List the group's keys. Owner-only. Never returns the secret or its hash. Params: `repo`, `limit`, `cursor`, `includeRevoked` (default `false`).
+List keys. Members see only keys they created; owners see all keys in the group. Never returns the secret or its hash. Params: `repo`, `limit`, `cursor`, `includeRevoked` (default `false`).
 
 ```json
 {
@@ -729,7 +729,7 @@ List the group's keys. Owner-only. Never returns the secret or its hash. Params:
 
 ### `POST /xrpc/app.certified.group.keys.delete`
 
-Revoke a key (soft-delete; rejected on next use). Owner-only. Idempotent.
+Revoke a key (soft-delete; rejected on next use). Members can revoke their own keys; owners can revoke any key in the group. Idempotent.
 
 Request body: `{ "repo": "did:plc:group123", "keyRef": "ab12cd34" }`. Response: `{ "keyRef": "ab12cd34", "revokedAt": "2026-06-06T13:00:00.000Z" }`. Errors: `Forbidden`, `KeyNotFound`.
 

--- a/docs/design/api-key-permission-sets.md
+++ b/docs/design/api-key-permission-sets.md
@@ -170,11 +170,11 @@ that surface is exactly: `member.list`, `audit.query` (rpc), the `repo:` write
 actions, and `uploadBlob` (blob).
 
 Consequently **no scope or set** can grant key administration (`keys.create`,
-`keys.delete`) or membership administration (`member.add`, `member.remove`,
-`role.set`) — deliberately not key-accessible (iteration-1 design; see the
-`keys.create` handler comment "a key cannot mint keys"). An `include:`-minted key
-is bounded by this just like an explicitly-scoped one: it cannot escalate by
-minting more keys nor alter the member roster.
+`keys.list`, `keys.delete`) or membership administration (`member.add`,
+`member.remove`, `role.set`) — deliberately not key-accessible (see the
+`keys.create` handler comment "a long-lived key cannot mint more keys"). An
+`include:`-minted key is bounded by this just like an explicitly-scoped one: it
+cannot escalate by minting more keys nor alter the member roster.
 
 Also CGS-specific: a key is bound to **one group** by storage (minted against the
 request's `repo`, stored in that group's per-group DB, only resolved under that

--- a/docs/design/api-keys.md
+++ b/docs/design/api-keys.md
@@ -261,10 +261,10 @@ It was considered and **rejected** for this feature. The reasons:
   complexity does.
 - **It reintroduces the credential we are trying to avoid holding.** A UCAN is
   signed by the holder's key, so for a platform backend to mint or refresh
-  UCANs on the owner's behalf it must hold the **owner's signing key material**
+  UCANs on a member's behalf it must hold that **member's signing key material**
   — exactly the situation the service-auth JWT path already imposes and the one
   this API-key design exists to escape. A revocable opaque key stored in the
-  platform backend is _less_ sensitive than the owner's signing key, not more.
+  platform backend is _less_ sensitive than a member's signing key, not more.
 - **Revocation is UCAN's weak spot.** Self-verifying tokens need a
   blacklist/CRL the verifier consults to revoke early — i.e. a central lookup,
   which negates the offline benefit and is precisely what our `revoked_at`
@@ -295,7 +295,7 @@ problem.
 ```text
 Platform backend                 Group Service                  Per-group DB
      |                                |                              |
-     |  (one-time, owner JWT auth)    |                              |
+     |  (one-time, member JWT auth)   |                              |
      |  keys.create {scopes:[...]}    |                              |
      |------------------------------->|  generate key                |
      |                                |  hash, store ----------------|--> group_api_keys
@@ -316,8 +316,9 @@ Three new pieces:
 1. **Request-level group targeting** (`repo`/explicit field) shared by both auth
    modes — see _Group targeting_. The DID comes from the request, never the key.
 2. A **key-auth branch** in the request path, parallel to the JWT branch.
-3. A **`group_api_keys` table** per group, plus three owner-only management
-   methods. No new global table — group isolation stays fully intact.
+3. A **`group_api_keys` table** per group, plus three JWT-authenticated
+   management methods. Members manage their own keys; owners can list and revoke
+   any key in the group. No new global table — group isolation stays fully intact.
 
 ---
 
@@ -363,9 +364,9 @@ data. Because the group is named by the request and located by forward hash,
 | -------------- | ---- | -------------------------------------------------------------- |
 | `key_ref`      | text | PK; the non-secret `<keyRef>` in the key string                |
 | `key_hash`     | text | SHA-256 of the secret; never the plaintext                     |
-| `name`         | text | owner-supplied label (e.g. "platform backend")                 |
+| `name`         | text | member-supplied label (e.g. "platform backend")                |
 | `scopes`       | text | JSON array of scope strings                                    |
-| `created_by`   | text | owner DID that minted the key                                  |
+| `created_by`   | text | member DID that minted the key                                 |
 | `created_at`   | text | `defaultTo(sql\`(datetime('now'))\`)`, per existing convention |
 | `last_used_at` | text | nullable; updated on use (best-effort)                         |
 | `revoked_at`   | text | nullable; set by `keys.delete` (soft delete)                   |
@@ -397,7 +398,7 @@ Proposed shape in `AuthVerifier` (`src/auth/verifier.ts`):
 ```ts
 // New credential variant
 export interface ApiKeyCredentials {
-  callerDid: string // the issuing owner's DID (see Open questions); key id travels in audit detail
+  callerDid: string // the issuing member's DID; key id travels in audit detail
   groupDid: string
   scopes: string[] // scope strings granted to this key
   authKind: 'apiKey'
@@ -449,16 +450,18 @@ request:
    `RpcPermission.scopeNeededFor({ lxm, aud })` gives the required scope and
    `ScopesSet.matches(...)` tests coverage (incl. wildcards). The package owns
    the grammar and matching semantics.
-2. **Role check (existing RBAC, unchanged):** the key acts on behalf of its
-   issuing owner. A key can never exceed the permissions of the role that
-   minted it, and is **further** narrowed by its scopes. First iteration's only
+2. **Role check (existing RBAC, unchanged):** the key acts on behalf of the
+   member who created it. A key can never exceed that member's current role,
+   and is **further** narrowed by its scopes. First iteration's only
    scope is a `member`-level read, so this is trivially satisfied, but the gate
    must enforce `effective = scopes ∩ role-perms`.
 
 Implementation: extend the gate so `assertCanWithAudit` (`src/api/util.ts`)
 understands a key principal — for an `apiKey` credential it runs the
 `@atproto/oauth-scopes` coverage check **and** the role-derived `canPerform`
-(`src/rbac/permissions.ts`), and logs the key id in the audit `detail`. Our
+(`src/rbac/permissions.ts`), and logs the key id in the audit `detail`. At
+creation time, `keys.create` also rejects scopes the caller's current role cannot
+use at all (for example, a member cannot mint an `audit.query` key). Our
 `Operation` union stays as the internal RBAC vocabulary; scope strings are the
 _external_ vocabulary, mapped to operations by a small lookup table.
 
@@ -482,15 +485,15 @@ ownership axis, so a member-issued key remains own-only. See _Authorization_.
 
 Audit logging already records `actor_did`, `action`, `result`
 (`group_audit_log`). Add a `detail.apiKeyRef` so key-driven actions are
-attributable to a specific key, not just to the owner DID.
+attributable to a specific key, not just to the issuing member DID.
 
 ---
 
 ## New lexicons / XRPC methods
 
-All three are **owner-only** and authenticated with the **existing JWT path**
-(an owner managing their keys is an interactive, high-trust action — keys
-should not be able to mint or revoke other keys in iteration 1).
+All three are authenticated with the **existing JWT path**. Any group member can
+create, list, and revoke their own keys; owners can list and revoke all keys in
+the group. Keys cannot mint, list, or revoke keys.
 
 ### `app.certified.group.keys.create` (procedure)
 
@@ -520,7 +523,7 @@ registered via `registerAuthedMethod` in `src/api/index.ts`.
 
 ## Worked example: platform membership sync
 
-1. Group owner logs in to the platform; platform mints an owner service-auth
+1. A group member logs in to the platform; platform mints that member's service-auth
    JWT as today.
 2. Platform calls `keys.create { name: "platform backend sync", scopes:
 ["rpc:app.certified.group.member.list"] }` → receives `cgsk_…` once.
@@ -528,23 +531,23 @@ registered via `registerAuthedMethod` in `src/api/index.ts`.
    only for one read-only op is far less sensitive than full read/write.)
 4. Backend polls `member.list { repo: <groupDid> }` indefinitely with
    `X-API-Key: cgsk_…` — the group named in the request, no JWT, no 2-minute
-   refresh, no owner credentials held.
-5. If the key leaks, owner calls `keys.delete`; the key dies on next use.
+   refresh, no member credentials held.
+5. If the key leaks, its creator — or any owner — calls `keys.delete`; the key dies on next use.
 
 ---
 
 ## Open questions
 
 - **Synthetic `callerDid` for key principals.** Audit/RBAC code assumes a DID
-  actor. Use the issuing owner's DID (attribute key actions to the owner, plus
-  `detail.apiKeyRef`), or a synthetic `did:cgs:key:<ref>`? Owner-DID is simpler
-  and keeps RBAC unchanged; synthetic is cleaner for attribution. Leaning
-  owner-DID + `apiKeyRef`.
+  actor. Use the issuing member's DID (attribute key actions to the member, plus
+  `detail.apiKeyRef`), or a synthetic `did:cgs:key:<ref>`? Member-DID is simpler
+  and keeps RBAC unchanged; synthetic is cleaner for attribution. Decision:
+  member-DID + `apiKeyRef`.
 - **`last_used_at` write cost.** Touching it per request adds a write to a
   read-only path. Make it best-effort / sampled, or drop it from iteration 1.
-- **Key vs owner role drift.** If the issuing owner is later demoted/removed,
-  should their keys keep working? Proposal: a key is invalid if its issuer no
-  longer holds the role required by the key's scopes (re-checked at use time).
+- **Key vs member role drift.** If the issuing member is later demoted/removed,
+  should their keys keep working? Decision: a key is invalid if its issuer no
+  longer holds the role required by the requested operation (re-checked at use time).
 - **Rotation.** No rotation primitive in iteration 1; revoke + create is the
   story. Add `keys.rotate` later if needed.
 - **Group-targeting field name & shape (part of #26).** Reuse the AT Protocol
@@ -579,7 +582,7 @@ registered via `registerAuthedMethod` in `src/api/index.ts`.
 - PDS-repo **read** scopes (proxying record reads through the group's PDS).
   Writes shipped in iteration 1; reads are the symmetric follow-up.
 - Finer-grained own-only write keys — see the limitation under _Authorization_:
-  today own-vs-any follows the issuing owner's role, since AT Protocol `repo:`
+  today own-vs-any follows the issuing member's role, since AT Protocol `repo:`
   scopes have no ownership axis. A future CGS-specific scope qualifier could let
   an admin mint a self-limited "own records only" key.
 - Permission **sets** (named scope bundles) via the `IncludeScope` primitive

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -671,18 +671,18 @@ rationale (unsigned `repo`, the resolution round-trip, security), see
 
 A service-auth JWT is short-lived (≤ 2 minutes) and single-use — correct for
 interactive, per-request access, but a poor fit for a **backend daemon** that wants
-to poll group data indefinitely without holding the owner's signing key. For that,
-an owner can issue a long-lived, scope-limited **API key**.
+to poll group data indefinitely without holding a member's signing key. For that,
+any group member can issue their own long-lived, scope-limited **API key**.
 
 The flow (the platform backend-sync example):
 
-1. **Owner mints a key** (one-time, with a normal owner JWT). The plaintext is
+1. **Member mints a key** (one-time, with that member's normal JWT). The plaintext is
    returned exactly once — store it in your backend secret store.
 
    ```typescript
    const { data } = await fetch(`${GROUP_SERVICE}/xrpc/app.certified.group.keys.create`, {
      method: 'POST',
-     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${ownerJwt}` },
+     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${memberJwt}` },
      body: JSON.stringify({
        repo: groupDid,
        name: 'platform backend',
@@ -709,8 +709,8 @@ The flow (the platform backend-sync example):
 3. **Revoke if leaked** — `app.certified.group.keys.delete { repo, keyRef }`. The
    key is rejected on its next use.
 
-A key is constrained by **both** its scopes and the role of the owner that issued it,
-and can only reach operations it is scoped for. A key can never manage keys.
+A key is constrained by **both** its scopes and the current role of the member who issued it,
+and can only reach operations it is scoped for. `keys.create` rejects scopes the caller's current role cannot use (for example, a plain member cannot mint an `audit.query` key). Demoting or removing that member automatically caps or disables their existing keys. A key can never manage keys.
 
 **Writes, too.** Keys aren't read-only: scope a key with `repo:<collection>?action=create|update|delete` to create/update/delete records, or `blob:<accept>` (e.g. `blob:image/*`) to upload blobs. Write calls are procedures, so put `repo` on the **querystring** as well as in the body (API-key auth resolves the group before the body is parsed):
 
@@ -728,7 +728,7 @@ await fetch(`${GROUP_SERVICE}/xrpc/app.certified.group.repo.createRecord?repo=${
 })
 ```
 
-A `repo:` scope picks the collection + action; the issuing owner's **role** still decides whose records may be touched — a member-issued key can only mutate records that member authored (`repo:` scopes have no own-vs-any axis). Storing a narrowly-scoped key is far less sensitive than holding the owner's signing key. See `docs/design/api-keys.md`.
+A `repo:` scope picks the collection + action; the issuing member's **role** still decides whose records may be touched — a member-issued key can only mutate records that member authored (`repo:` scopes have no own-vs-any axis). Storing a narrowly-scoped key is far less sensitive than holding a member's signing key. See `docs/design/api-keys.md`.
 
 ### Permission sets: granting whole namespaces at once
 

--- a/e2e/step-definitions/api-keys.steps.ts
+++ b/e2e/step-definitions/api-keys.steps.ts
@@ -1,7 +1,7 @@
 /**
  * Steps for api-keys.feature — the platform backend-sync flow (#26):
- * owner mints a scoped key (JWT-authed keys.create), a backend uses it via the
- * X-API-Key header (no JWT), and the owner revokes it. Group targeting is the
+ * a member mints a scoped key (JWT-authed keys.create), a backend uses it via the
+ * X-API-Key header (no JWT), and the creator or owner revokes it. Group targeting is the
  * same request-level `repo` the JWT new path uses.
  */
 import { When, Then, Given } from '@cucumber/cucumber'
@@ -16,8 +16,13 @@ const KEYS_DELETE = 'app.certified.group.keys.delete'
 const MEMBER_LIST = 'app.certified.group.member.list'
 const AUDIT_QUERY = 'app.certified.group.audit.query'
 
-function ownerCreds(world: CgsWorld) {
-  return { identifier: world.env.ownerIdentifier, password: world.env.ownerPassword }
+type KeyActor = 'owner' | 'member'
+
+function credsFor(world: CgsWorld, actor: KeyActor) {
+  if (actor === 'owner') {
+    return { identifier: world.env.ownerIdentifier, password: world.env.ownerPassword }
+  }
+  return { identifier: world.env.memberIdentifier, password: world.env.memberPassword }
 }
 
 const FEED_POST = 'app.bsky.feed.post'
@@ -29,10 +34,14 @@ function memberListScope(world: CgsWorld): string {
   return scope
 }
 
-/** Mint an API key with the given scopes (owner-authed keys.create). */
-async function createKey(world: CgsWorld, scopes: string[]): Promise<void> {
+/** Mint an API key with the given scopes (JWT-authed keys.create). */
+async function createKey(
+  world: CgsWorld,
+  scopes: string[],
+  actor: KeyActor = 'owner',
+): Promise<void> {
   const token = await mintServiceAuth({
-    ...ownerCreds(world),
+    ...credsFor(world, actor),
     aud: world.serviceDid,
     lxm: KEYS_CREATE,
   })
@@ -40,11 +49,16 @@ async function createKey(world: CgsWorld, scopes: string[]): Promise<void> {
     cgsUrl: world.env.cgsUrl,
     nsid: KEYS_CREATE,
     token,
-    body: { repo: world.groupDid, name: 'platform backend e2e key', scopes },
+    body: { repo: world.groupDid, name: `${actor} platform backend e2e key`, scopes },
   })
   if (world.lastHttpStatus === 200 && world.lastHttpJson) {
     world.apiKey = world.lastHttpJson.key as string
     world.apiKeyRef = world.lastHttpJson.keyRef as string
+    if (actor === 'owner') {
+      world.ownerApiKeyRef = world.apiKeyRef
+    } else {
+      world.memberApiKeyRef = world.apiKeyRef
+    }
   }
 }
 
@@ -52,8 +66,18 @@ When('the owner creates an API key scoped to member.list', async function (this:
   await createKey(this, [memberListScope(this)])
 })
 
+When('the member creates an API key scoped to member.list', async function (this: CgsWorld) {
+  await createKey(this, [memberListScope(this)], 'member')
+})
+
 Given('the owner has created an API key scoped to member.list', async function (this: CgsWorld) {
   await createKey(this, [memberListScope(this)])
+  assert.equal(this.lastHttpStatus, 200, 'key creation should succeed in setup')
+  assert.ok(this.apiKey, 'an API key should have been returned')
+})
+
+Given('the member has created an API key scoped to member.list', async function (this: CgsWorld) {
+  await createKey(this, [memberListScope(this)], 'member')
   assert.equal(this.lastHttpStatus, 200, 'key creation should succeed in setup')
   assert.ok(this.apiKey, 'an API key should have been returned')
 })
@@ -86,35 +110,57 @@ When('a backend queries the audit log using the API key', async function (this: 
   })
 })
 
-When('the owner revokes the API key', async function (this: CgsWorld) {
-  assert.ok(this.apiKeyRef, 'no keyRef available to revoke')
+async function revokeKey(world: CgsWorld, actor: KeyActor): Promise<void> {
+  assert.ok(world.apiKeyRef, 'no keyRef available to revoke')
   const token = await mintServiceAuth({
-    ...ownerCreds(this),
-    aud: this.serviceDid,
+    ...credsFor(world, actor),
+    aud: world.serviceDid,
     lxm: KEYS_DELETE,
   })
-  await callXrpc(this, {
-    cgsUrl: this.env.cgsUrl,
+  await callXrpc(world, {
+    cgsUrl: world.env.cgsUrl,
     nsid: KEYS_DELETE,
     token,
-    body: { repo: this.groupDid, keyRef: this.apiKeyRef },
+    body: { repo: world.groupDid, keyRef: world.apiKeyRef },
   })
+}
+
+When('the owner revokes the API key', async function (this: CgsWorld) {
+  await revokeKey(this, 'owner')
 })
 
-When('the owner lists the group API keys', async function (this: CgsWorld) {
+When('the member revokes the API key', async function (this: CgsWorld) {
+  await revokeKey(this, 'member')
+})
+
+async function listKeys(world: CgsWorld, actor: KeyActor): Promise<void> {
   const token = await mintServiceAuth({
-    ...ownerCreds(this),
-    aud: this.serviceDid,
+    ...credsFor(world, actor),
+    aud: world.serviceDid,
     lxm: KEYS_LIST,
   })
-  await callXrpc(this, {
-    cgsUrl: this.env.cgsUrl,
+  await callXrpc(world, {
+    cgsUrl: world.env.cgsUrl,
     nsid: KEYS_LIST,
     token,
     method: 'GET',
-    repo: this.groupDid,
+    repo: world.groupDid,
   })
+}
+
+When('the owner lists the group API keys', async function (this: CgsWorld) {
+  await listKeys(this, 'owner')
 })
+
+When('the member lists the group API keys', async function (this: CgsWorld) {
+  await listKeys(this, 'member')
+})
+
+function listedKeyRefs(world: CgsWorld): string[] {
+  const json = world.lastHttpJson as { keys?: Array<{ keyRef?: string }> } | undefined
+  assert.ok(Array.isArray(json?.keys), `expected keys array, got ${world.lastHttpBody}`)
+  return json.keys.map((key) => key.keyRef).filter((keyRef): keyRef is string => Boolean(keyRef))
+}
 
 Then('the API key list does not contain any secret material', function (this: CgsWorld) {
   const body = this.lastHttpBody ?? ''
@@ -124,6 +170,25 @@ Then('the API key list does not contain any secret material', function (this: Cg
     assert.ok(!('key' in key), 'key entry must not include the plaintext')
     assert.ok(!('key_hash' in key) && !('keyHash' in key), 'key entry must not include the hash')
   }
+})
+
+Then('the API key list contains the member key but not the owner key', function (this: CgsWorld) {
+  assert.ok(this.memberApiKeyRef, 'expected a member-created keyRef')
+  assert.ok(this.ownerApiKeyRef, 'expected an owner-created keyRef')
+  const refs = listedKeyRefs(this)
+  assert.ok(refs.includes(this.memberApiKeyRef), `missing member key ${this.memberApiKeyRef}`)
+  assert.ok(
+    !refs.includes(this.ownerApiKeyRef),
+    `member list leaked owner key ${this.ownerApiKeyRef}`,
+  )
+})
+
+Then('the API key list contains both the member and owner keys', function (this: CgsWorld) {
+  assert.ok(this.memberApiKeyRef, 'expected a member-created keyRef')
+  assert.ok(this.ownerApiKeyRef, 'expected an owner-created keyRef')
+  const refs = listedKeyRefs(this)
+  assert.ok(refs.includes(this.memberApiKeyRef), `missing member key ${this.memberApiKeyRef}`)
+  assert.ok(refs.includes(this.ownerApiKeyRef), `missing owner key ${this.ownerApiKeyRef}`)
 })
 
 Given(

--- a/e2e/support/world.ts
+++ b/e2e/support/world.ts
@@ -33,6 +33,8 @@ export class CgsWorld extends World implements HttpSink {
   /** API key plaintext + ref carried between create → use → revoke steps (#26). */
   apiKey?: string
   apiKeyRef?: string
+  ownerApiKeyRef?: string
+  memberApiKeyRef?: string
 
   get env() {
     return testEnv

--- a/features/api-keys.feature
+++ b/features/api-keys.feature
@@ -1,10 +1,10 @@
-Feature: API keys — owner-issued, scope-limited bearer credentials (#26)
-  An owner mints a long-lived, scope-limited API key so a backend daemon can
-  poll group data without holding the owner's signing key or minting a fresh
+Feature: API keys — member-issued, scope-limited bearer credentials (#26, #57)
+  A group member mints a long-lived, scope-limited API key so a backend daemon can
+  poll group data without holding that member's signing key or minting a fresh
   service-auth JWT every two minutes. The key authenticates via the X-API-Key
   header; the group is named by `repo` (the same request-level targeting the
-  JWT new path uses). Keys are owner-managed (create / list / delete) and die on
-  next use once revoked.
+  JWT new path uses). Members manage their own keys; owners can list and revoke
+  all group keys. Keys die on next use once revoked.
 
   This is the platform backend-sync worked example from docs/design/api-keys.md.
 
@@ -20,9 +20,28 @@ Feature: API keys — owner-issued, scope-limited bearer credentials (#26)
     Then the response status is 200
     And the response has no deprecation header
 
+  @needs-rbac-accounts
+  Scenario: Member mints a member.list key and a backend uses it to list members
+    Given the owner has seeded the admin and member accounts
+    When the member creates an API key scoped to member.list
+    Then the response status is 200
+    And the response contains an API key and keyRef
+    When a backend lists the group members using the API key
+    Then the response status is 200
+    And the response has no deprecation header
+
   Scenario: A revoked key is rejected on next use
     Given the owner has created an API key scoped to member.list
     When the owner revokes the API key
+    Then the response status is 200
+    When a backend lists the group members using the API key
+    Then the response status is 401
+
+  @needs-rbac-accounts
+  Scenario: A member can revoke their own key
+    Given the owner has seeded the admin and member accounts
+    And the member has created an API key scoped to member.list
+    When the member revokes the API key
     Then the response status is 200
     When a backend lists the group members using the API key
     Then the response status is 401
@@ -37,6 +56,19 @@ Feature: API keys — owner-issued, scope-limited bearer credentials (#26)
     When the owner lists the group API keys
     Then the response status is 200
     And the API key list does not contain any secret material
+
+  @needs-rbac-accounts
+  Scenario: Member key listings are self-scoped while owners see all keys
+    Given the owner has seeded the admin and member accounts
+    And the owner has created an API key scoped to member.list
+    When the member creates an API key scoped to member.list
+    Then the response status is 200
+    When the member lists the group API keys
+    Then the response status is 200
+    And the API key list contains the member key but not the owner key
+    When the owner lists the group API keys
+    Then the response status is 200
+    And the API key list contains both the member and owner keys
 
   Scenario: A write-scoped key can create a record via X-API-Key
     Given the owner has created an API key scoped to create feed posts

--- a/lexicons/app/certified/group/keys/create.json
+++ b/lexicons/app/certified/group/keys/create.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "procedure",
-      "description": "Mint a long-lived, scope-limited API key for the group. Owner-only. The plaintext key is returned exactly once and never retrievable again.",
+      "description": "Mint a long-lived, scope-limited API key for the caller's group membership. Member-authenticated JWT only; API keys cannot mint more keys. The plaintext key is returned exactly once and never retrievable again.",
       "input": {
         "encoding": "application/json",
         "schema": {

--- a/lexicons/app/certified/group/keys/delete.json
+++ b/lexicons/app/certified/group/keys/delete.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "procedure",
-      "description": "Revoke an API key by its keyRef. Owner-only. Soft-delete: the key is rejected on its next use.",
+      "description": "Revoke an API key by its keyRef. Members can revoke their own keys; owners can revoke any key in the group. JWT only; API keys cannot revoke keys. Soft-delete: the key is rejected on its next use.",
       "input": {
         "encoding": "application/json",
         "schema": {

--- a/lexicons/app/certified/group/keys/list.json
+++ b/lexicons/app/certified/group/keys/list.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "query",
-      "description": "List API keys issued for the group. Owner-only. Never returns the secret or its hash.",
+      "description": "List API keys issued for the group. Members see only their own keys; owners see all keys. JWT only; API keys cannot list keys. Never returns the secret or its hash.",
       "parameters": {
         "type": "params",
         "properties": {

--- a/src/api/keys/create.ts
+++ b/src/api/keys/create.ts
@@ -1,5 +1,6 @@
 import type { Server } from '@atproto/xrpc-server'
 import { XRPCError } from '@atproto/xrpc-server'
+import { ForbiddenError } from '../../errors.js'
 import type { AppContext } from '../../context.js'
 import {
   registerAuthedMethod,
@@ -9,7 +10,11 @@ import {
   sqliteToIso,
 } from '../util.js'
 import { generateApiKey } from '../../auth/api-key.js'
-import { canonicalizeScopes, expandIncludes } from '../../auth/scopes.js'
+import {
+  canonicalizeScopes,
+  expandIncludes,
+  validateScopesAllowedForRole,
+} from '../../auth/scopes.js'
 
 export default function (server: Server, ctx: AppContext) {
   registerAuthedMethod(server, 'app.certified.group.keys.create', ctx, {
@@ -30,11 +35,32 @@ export default function (server: Server, ctx: AppContext) {
         throw new XRPCError(400, 'At least one scope is required', 'InvalidRequest')
       }
 
+      const groupDid = await resolveGroupDid(ctx, auth.credentials, repo)
+      const groupDb = ctx.groupDbs.get(groupDid)
+
+      // Any group member may mint their own API keys. Passing the principal
+      // means an apiKey caller is still rejected here: keys.create has no scope
+      // mapping, so a long-lived key cannot mint more keys.
+      const callerRole = await assertCanWithAudit(
+        ctx,
+        groupDb,
+        callerDid,
+        'keys.create',
+        undefined,
+        {
+          authKind,
+          scopes: callerScopes,
+          apiKeyRef,
+        },
+      )
+
       // Expand any `include:<nsid>` permission-set scopes to the concrete
       // `rpc:`/`repo:` scopes they bundle (resolved via Lexicon resolution), then
-      // canonicalize. A key stores only concrete scopes — the `include:` is a
-      // create-time convenience and is never persisted. Non-`include:` scopes
-      // pass through untouched.
+      // canonicalize. This intentionally happens after authorization so API-key
+      // callers and non-members are rejected before any external DNS/PDS work.
+      // A key stores only concrete scopes — the `include:` is a create-time
+      // convenience and is never persisted. Non-`include:` scopes pass through
+      // untouched.
       const expanded = await expandIncludes(scopes, ctx.config.serviceDid, ctx.permissionSets)
       if (!expanded.ok) {
         throw new XRPCError(
@@ -55,17 +81,16 @@ export default function (server: Server, ctx: AppContext) {
       }
       const storedScopes = canon.scopes
 
-      const groupDid = await resolveGroupDid(ctx, auth.credentials, repo)
-      const groupDb = ctx.groupDbs.get(groupDid)
-
-      // Owner-only. Passing the principal means an apiKey caller is rejected here
-      // too: keys.create has no scope mapping, so the scope check denies it — a
-      // key cannot mint keys in iteration 1.
-      await assertCanWithAudit(ctx, groupDb, callerDid, 'keys.create', undefined, {
-        authKind,
-        scopes: callerScopes,
-        apiKeyRef,
-      })
+      const roleValidation = validateScopesAllowedForRole(storedScopes, callerRole)
+      if (!roleValidation.ok) {
+        await ctx.audit.log(groupDb, callerDid, 'keys.create', 'denied', {
+          name,
+          scopes: storedScopes,
+          rejectedScope: roleValidation.scope,
+          reason: roleValidation.reason,
+        })
+        throw new ForbiddenError(roleValidation.reason)
+      }
 
       const key = generateApiKey()
 

--- a/src/api/keys/delete.ts
+++ b/src/api/keys/delete.ts
@@ -1,6 +1,7 @@
 import type { Server } from '@atproto/xrpc-server'
 import { XRPCError } from '@atproto/xrpc-server'
 import { sql } from 'kysely'
+import { ForbiddenError } from '../../errors.js'
 import type { AppContext } from '../../context.js'
 import {
   registerAuthedMethod,
@@ -26,20 +27,36 @@ export default function (server: Server, ctx: AppContext) {
       const groupDid = await resolveGroupDid(ctx, auth.credentials, repo)
       const groupDb = ctx.groupDbs.get(groupDid)
 
-      // Owner-only. An apiKey caller is denied (keys.delete has no scope mapping).
-      await assertCanWithAudit(ctx, groupDb, callerDid, 'keys.delete', undefined, {
-        authKind,
-        scopes,
-        apiKeyRef,
-      })
+      // Any group member may revoke their own keys; owners can revoke every key
+      // in the group. API-key callers are denied (keys.delete has no scope
+      // mapping), so long-lived keys cannot revoke keys.
+      const callerRole = await assertCanWithAudit(
+        ctx,
+        groupDb,
+        callerDid,
+        'keys.delete',
+        undefined,
+        {
+          authKind,
+          scopes,
+          apiKeyRef,
+        },
+      )
 
       const existing = await groupDb
         .selectFrom('group_api_keys')
-        .select(['revoked_at'])
+        .select(['created_by', 'revoked_at'])
         .where('key_ref', '=', keyRef)
         .executeTakeFirst()
       if (!existing) {
         throw new XRPCError(404, 'API key not found', 'KeyNotFound')
+      }
+      if (callerRole !== 'owner' && existing.created_by !== callerDid) {
+        await ctx.audit.log(groupDb, callerDid, 'keys.delete', 'denied', {
+          revokedKeyRef: keyRef,
+          reason: "Cannot revoke another member's API key",
+        })
+        throw new ForbiddenError("Cannot revoke another member's API key")
       }
 
       // Idempotent: a revoked key keeps its original revocation time. Only set it

--- a/src/api/keys/list.ts
+++ b/src/api/keys/list.ts
@@ -19,8 +19,10 @@ export default function (server: Server, ctx: AppContext) {
       }
       const groupDb = ctx.groupDbs.get(groupDid)
 
-      // Owner-only. An apiKey caller is denied (keys.list has no scope mapping).
-      await assertCanWithAudit(ctx, groupDb, callerDid, 'keys.list', undefined, {
+      // Any group member may list their own keys; owners can list every key in
+      // the group. API-key callers are denied (keys.list has no scope mapping),
+      // so long-lived keys cannot enumerate keys.
+      const callerRole = await assertCanWithAudit(ctx, groupDb, callerDid, 'keys.list', undefined, {
         authKind,
         scopes,
         apiKeyRef,
@@ -47,6 +49,9 @@ export default function (server: Server, ctx: AppContext) {
 
       if (!includeRevoked) {
         query = query.where('revoked_at', 'is', null)
+      }
+      if (callerRole !== 'owner') {
+        query = query.where('created_by', '=', callerDid)
       }
 
       // Cursor: base64 of "created_at::key_ref" (matches the sort).

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -4,7 +4,7 @@ import type { Kysely } from 'kysely'
 import type { AppContext } from '../context.js'
 import type { GroupAuthResult, ServiceAuthResult } from '../auth/verifier.js'
 import type { AuditEventDetail } from '../audit.js'
-import type { Operation } from '../rbac/permissions.js'
+import type { Operation, Role } from '../rbac/permissions.js'
 import type { GroupDatabase } from '../db/schema.js'
 import { XRPCError as ClientXRPCError } from '@atproto/xrpc'
 import { XRPCError, UpstreamFailureError, ForbiddenError } from '@atproto/xrpc-server'
@@ -107,10 +107,10 @@ export function decodeCursor(cursor: string): string {
  * For an `apiKey` principal two checks must BOTH pass (design: scopes ∩
  * role-perms): first the scope check (does the key's granted scope set cover
  * this operation, delegated to `@atproto/oauth-scopes`), then the existing role
- * check (the key acts as its issuing owner, so the role check naturally caps the
+ * check (the key acts as its issuing member, so the role check naturally caps the
  * key at its issuer's role). A JWT principal is scope-unlimited — only the role
  * check applies. The specific key (`apiKeyRef`) is attached to the audit detail
- * so key-driven actions are attributable beyond the owner DID.
+ * so key-driven actions are attributable beyond the issuing member DID.
  */
 export async function assertCanWithAudit(
   ctx: AppContext,
@@ -119,7 +119,7 @@ export async function assertCanWithAudit(
   operation: Operation,
   detail?: Omit<AuditEventDetail, 'reason'>,
   principal?: GatePrincipal,
-): Promise<void> {
+): Promise<Role> {
   const auditDetail: Omit<AuditEventDetail, 'reason'> | undefined =
     principal?.authKind === 'apiKey' && principal.apiKeyRef
       ? { ...detail, apiKeyRef: principal.apiKeyRef }
@@ -155,7 +155,7 @@ export async function assertCanWithAudit(
   }
 
   try {
-    await ctx.rbac.assertCan(groupDb, callerDid, operation)
+    return await ctx.rbac.assertCan(groupDb, callerDid, operation)
   } catch (err) {
     await ctx.audit.log(groupDb, callerDid, operation, 'denied', {
       ...auditDetail,

--- a/src/auth/scopes.ts
+++ b/src/auth/scopes.ts
@@ -6,7 +6,7 @@ import {
   IncludeScope,
 } from '@atproto/oauth-scopes'
 import type { RepoAction } from '@atproto/oauth-scopes'
-import type { Operation } from '../rbac/permissions.js'
+import { canPerform, type Operation, type Role } from '../rbac/permissions.js'
 import { SERVICE_ID_FRAGMENT } from '../did-document.js'
 import type { PermissionSetResolver } from './permission-set-resolver.js'
 import { PermissionSetResolutionError } from './permission-set-resolver.js'
@@ -40,7 +40,7 @@ export function serviceScopeAud(serviceDid: string): string {
  * Map an internal RBAC `Operation` to the XRPC method NSID (lxm) a key scope is
  * declared against. Only operations reachable by an API key need an entry; an
  * operation with no mapping is **not** key-accessible (the gate denies it for
- * key callers). Iteration 1 grants only `member.list`.
+ * key callers). Key-management operations intentionally have no mapping.
  */
 const OPERATION_LXM: Partial<Record<Operation, string>> = {
   'member.list': 'app.certified.group.member.list',
@@ -50,6 +50,15 @@ const OPERATION_LXM: Partial<Record<Operation, string>> = {
 /** The lxm an operation maps to, or undefined if it is not key-accessible. */
 export function lxmForOperation(operation: Operation): string | undefined {
   return OPERATION_LXM[operation]
+}
+
+function operationForLxm(lxm: string): Operation | undefined {
+  for (const [operation, mappedLxm] of Object.entries(OPERATION_LXM) as Array<
+    [Operation, string]
+  >) {
+    if (mappedLxm === lxm) return operation
+  }
+  return undefined
 }
 
 /**
@@ -132,6 +141,49 @@ export function repoScopesCover(
 export function blobScopesCover(grantedScopes: string[], mime: string): boolean {
   const granted = ScopesSet.fromString(grantedScopes.join(' '))
   return granted.matches('blob', { mime })
+}
+
+export type ScopeRoleValidation = { ok: true } | { ok: false; scope: string; reason: string }
+
+/**
+ * Validate that a caller's current role can ever use the requested scopes.
+ *
+ * Runtime authorization still re-checks the issuer's current role on every API
+ * key request, so demotions/removals immediately cap or disable existing keys.
+ * This create-time check avoids minting obviously dead/escalating grants such as
+ * a member-issued `audit.query` RPC scope. `repo:` scopes are allowed for any
+ * member because the scope language has no own-vs-any axis; the request-time
+ * RBAC check still decides whether a concrete write is own-only or admin-any.
+ */
+export function validateScopesAllowedForRole(scopes: string[], role: Role): ScopeRoleValidation {
+  for (const scope of scopes) {
+    const rpc = RpcPermission.fromString(scope)
+    if (rpc !== null) {
+      const operations = rpc.lxm.includes('*')
+        ? (Object.keys(OPERATION_LXM) as Operation[])
+        : rpc.lxm.map((lxm) => operationForLxm(lxm))
+
+      if (operations.includes(undefined)) {
+        return { ok: false, scope, reason: 'scope names an operation that is not key-accessible' }
+      }
+      const concreteOperations = operations as Operation[]
+      if (concreteOperations.length === 0) {
+        return { ok: false, scope, reason: 'scope does not grant any key-accessible operation' }
+      }
+      const denied = concreteOperations.find((operation) => !canPerform(role, operation))
+      if (denied !== undefined) {
+        return { ok: false, scope, reason: `role '${role}' cannot use scope for '${denied}'` }
+      }
+      continue
+    }
+
+    if (RepoPermission.fromString(scope) !== null || BlobPermission.fromString(scope) !== null) {
+      continue
+    }
+
+    return { ok: false, scope, reason: 'unsupported scope kind (expected rpc:, repo: or blob:)' }
+  }
+  return { ok: true }
 }
 
 /**
@@ -274,31 +326,31 @@ export async function expandIncludes(
   const out: string[] = []
   for (const scope of scopes) {
     const inc = IncludeScope.fromString(scope)
-    if (inc === null) {
+    if (inc !== null) {
+      let set
+      try {
+        set = await resolver.resolve(inc.nsid)
+      } catch (err) {
+        const reason =
+          err instanceof PermissionSetResolutionError
+            ? err.reason
+            : err instanceof Error
+              ? err.message
+              : String(err)
+        return { ok: false, scope, reason }
+      }
+      // Re-stamp with our aud so `inheritAud` rpc: permissions inherit it on
+      // expansion (no-op for aud-less repo: permissions).
+      const bound = IncludeScope.fromString(`include:${inc.nsid}?aud=${encodeURIComponent(aud)}`)
+      const expanded = (bound ?? inc).toScopes(set)
+      if (expanded.length === 0) {
+        return { ok: false, scope, reason: 'permission set expanded to no scopes' }
+      }
+      out.push(...expanded)
+    } else {
       // Not an `include:` — pass through for canonicalizeScopes to validate.
       out.push(scope)
-      continue
     }
-    let set
-    try {
-      set = await resolver.resolve(inc.nsid)
-    } catch (err) {
-      const reason =
-        err instanceof PermissionSetResolutionError
-          ? err.reason
-          : err instanceof Error
-            ? err.message
-            : String(err)
-      return { ok: false, scope, reason }
-    }
-    // Re-stamp with our aud so `inheritAud` rpc: permissions inherit it on
-    // expansion (no-op for aud-less repo: permissions).
-    const bound = IncludeScope.fromString(`include:${inc.nsid}?aud=${encodeURIComponent(aud)}`)
-    const expanded = (bound ?? inc).toScopes(set)
-    if (expanded.length === 0) {
-      return { ok: false, scope, reason: 'permission set expanded to no scopes' }
-    }
-    out.push(...expanded)
   }
   return { ok: true, scopes: out }
 }

--- a/src/auth/verifier.ts
+++ b/src/auth/verifier.ts
@@ -83,7 +83,7 @@ export interface GroupAuthCredentials {
   scopes?: string[]
   /**
    * The non-secret key id (apiKey only), for attributing audit-log entries to a
-   * specific key rather than just the issuing owner DID.
+   * specific key rather than just the issuing member DID.
    */
   apiKeyRef?: string
 }
@@ -155,10 +155,14 @@ export class AuthVerifier {
   }
 
   private assertTokenLifetime(payload: { iat?: number; exp?: number }): void {
-    if (payload.iat == null) {
+    if (payload.iat === undefined || payload.iat === null) {
       throw new AuthRequiredError('Missing iat in service auth token')
     }
-    if (payload.exp != null && payload.exp - payload.iat > NONCE_TTL_SECONDS) {
+    if (
+      payload.exp !== undefined &&
+      payload.exp !== null &&
+      payload.exp - payload.iat > NONCE_TTL_SECONDS
+    ) {
       throw new AuthRequiredError('Token lifetime exceeds nonce window')
     }
   }
@@ -386,7 +390,7 @@ export class AuthVerifier {
       this.logApiKeyFailure('Invalid API key', {
         keyRef: parsed.keyRef,
         groupDid,
-        revoked: row?.revoked_at != null,
+        revoked: row?.revoked_at !== undefined && row.revoked_at !== null,
       })
       throw new AuthRequiredError('Invalid API key')
     }
@@ -412,8 +416,8 @@ export class AuthVerifier {
       throw new AuthRequiredError('Corrupt API-key scopes')
     }
 
-    // The key acts on behalf of its issuing owner (design Open Question lean:
-    // owner-DID + apiKeyRef for attribution). RBAC stays DID-based.
+    // The key acts on behalf of the member who created it. RBAC stays DID-based,
+    // so demotions/removals automatically cap or disable existing keys.
     return { callerDid: row.created_by, groupDid, scopes, apiKeyRef: parsed.keyRef }
   }
 

--- a/src/db/migrations/group/004_api_keys.ts
+++ b/src/db/migrations/group/004_api_keys.ts
@@ -10,7 +10,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn('name', 'text', (col) => col.notNull())
     // JSON array of @atproto/oauth-scopes scope strings.
     .addColumn('scopes', 'text', (col) => col.notNull())
-    // Owner DID that minted the key.
+    // Member DID that minted the key.
     .addColumn('created_by', 'text', (col) => col.notNull())
     .addColumn('created_at', 'text', (col) => col.defaultTo(sql`(datetime('now'))`).notNull())
     // Best-effort last-use timestamp; null until first use.

--- a/src/rbac/permissions.ts
+++ b/src/rbac/permissions.ts
@@ -40,12 +40,12 @@ const MIN_ROLE_FOR_OPERATION: Record<Operation, Role> = {
   'audit.query': 'admin',
   'role.set': 'owner',
   'group.destroy': 'owner',
-  // API-key management is owner-only and JWT-authed. These ops have no entry in
-  // the scope→lxm map (src/auth/scopes.ts), so an apiKey caller can never reach
-  // them — a key cannot mint or revoke keys in iteration 1.
-  'keys.create': 'owner',
-  'keys.list': 'owner',
-  'keys.delete': 'owner',
+  // API-key management is member-level but JWT-authenticated. These ops have no
+  // entry in the scope→lxm map (src/auth/scopes.ts), so an apiKey caller can
+  // never reach them — a key cannot mint, list, or revoke keys.
+  'keys.create': 'member',
+  'keys.list': 'member',
+  'keys.delete': 'member',
 }
 
 export function canPerform(userRole: Role, operation: Operation): boolean {

--- a/tests/api-key-scope-enforcement.test.ts
+++ b/tests/api-key-scope-enforcement.test.ts
@@ -3,8 +3,8 @@
  *
  * The gate (assertCanWithAudit) only enforces scopes when the handler passes the
  * caller's credentials. A handler that forgot to pass them would let a key act
- * with its owner's full role — a scope bypass (caught in e2e: audit.query
- * returned 200 for a member.list-only key). These tests exercise the real
+ * with its issuing member's full role — a scope bypass (caught in e2e:
+ * audit.query returned 200 for a member.list-only key). These tests exercise the real
  * handlers with an apiKey principal to prove every key-reachable handler routes
  * the principal into the gate.
  */
@@ -21,16 +21,17 @@ import type { GroupDatabase } from '../src/db/schema.js'
 const SERVICE_DID = 'did:web:test.example.com'
 const GROUP = 'did:plc:testgroup'
 const MEMBER_LIST_SCOPE = scopeNeededFor('member.list', SERVICE_DID)!
+const AUDIT_QUERY_SCOPE = scopeNeededFor('audit.query', SERVICE_DID)!
 
 /** Build an AuthVerifier mock whose xrpcAuth() yields an apiKey principal. */
-function apiKeyAuth(scopes: string[]) {
+function apiKeyAuth(scopes: string[], callerDid = 'did:plc:owner') {
   return {
-    verifyServiceAuth: async () => ({ iss: 'did:plc:owner' }),
+    verifyServiceAuth: async () => ({ iss: callerDid }),
     resolveRepoToGroup: async () => GROUP,
     xrpcAuth() {
       return async () => ({
         credentials: {
-          callerDid: 'did:plc:owner', // key acts as the owner (admin+)
+          callerDid,
           groupDid: GROUP,
           legacyAud: false,
           authKind: 'apiKey' as const,
@@ -40,7 +41,7 @@ function apiKeyAuth(scopes: string[]) {
       })
     },
     xrpcServiceAuth() {
-      return async () => ({ credentials: { callerDid: 'did:plc:owner' } })
+      return async () => ({ credentials: { callerDid } })
     },
   } as unknown as AppContext['authVerifier']
 }
@@ -53,7 +54,7 @@ describe('API-key scope enforcement at the handler layer', () => {
     const test = await createTestContext()
     ctx = test.ctx
     groupDb = test.groupDb
-    // The issuing owner is an admin+ by role, so any bypass would surface as a
+    // The issuing member is an admin+ by role, so any bypass would surface as a
     // role-permitted 200 rather than a scope-denied 403.
     await seedMember(groupDb, 'did:plc:owner', 'owner')
   })
@@ -86,6 +87,32 @@ describe('API-key scope enforcement at the handler layer', () => {
 
   it('member.list: a key with NO scopes is denied (403)', async () => {
     ctx.authVerifier = apiKeyAuth([])
+    const res = await request(app(memberListHandler)).get(
+      `/xrpc/app.certified.group.member.list?repo=${GROUP}`,
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('audit.query: an admin-issued key with audit.query scope is allowed (200)', async () => {
+    await seedMember(groupDb, 'did:plc:admin', 'admin')
+    ctx.authVerifier = apiKeyAuth([AUDIT_QUERY_SCOPE], 'did:plc:admin')
+    const res = await request(app(auditQueryHandler)).get(
+      `/xrpc/app.certified.group.audit.query?repo=${GROUP}`,
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it('audit.query: a member-issued key is capped by member role even with audit.query scope', async () => {
+    await seedMember(groupDb, 'did:plc:member', 'member')
+    ctx.authVerifier = apiKeyAuth([AUDIT_QUERY_SCOPE], 'did:plc:member')
+    const res = await request(app(auditQueryHandler)).get(
+      `/xrpc/app.certified.group.audit.query?repo=${GROUP}`,
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('member.list: a removed issuer is denied even when the key scope covers the operation', async () => {
+    ctx.authVerifier = apiKeyAuth([MEMBER_LIST_SCOPE], 'did:plc:removed')
     const res = await request(app(memberListHandler)).get(
       `/xrpc/app.certified.group.member.list?repo=${GROUP}`,
     )

--- a/tests/api-key-writes.test.ts
+++ b/tests/api-key-writes.test.ts
@@ -1,7 +1,7 @@
 /**
  * Handler-level tests: an API key with the right repo:/blob: scope can perform
  * PDS-repo writes; an under-scoped key is denied; and the RBAC role check still
- * applies underneath (own-vs-any follows the issuing owner's role, since repo:
+ * applies underneath (own-vs-any follows the issuing member's role, since repo:
  * scopes have no ownership axis).
  */
 import { describe, it, expect, beforeEach } from 'vitest'
@@ -131,6 +131,17 @@ describe('API-key writes — role still enforced under the scope (own vs any)', 
       .post(`/xrpc/com.atproto.repo.deleteRecord?repo=${GROUP}`)
       .send(delBody('other1'))
     expect(res.status).toBe(403)
+  })
+
+  it("an admin-issued key can delete another member's record when scope covers delete", async () => {
+    await seedMember(groupDb, 'did:plc:admin', 'admin')
+    const uri = `at://${GROUP}/${POST}/other2`
+    await seedAuthorship(groupDb, uri, 'did:plc:someoneelse', POST)
+    ctx.authVerifier = apiKeyAuth([`repo:${POST}?action=delete`], 'did:plc:admin')
+    const res = await request(app())
+      .post(`/xrpc/com.atproto.repo.deleteRecord?repo=${GROUP}`)
+      .send(delBody('other2'))
+    expect(res.status).toBe(200)
   })
 })
 

--- a/tests/gate.test.ts
+++ b/tests/gate.test.ts
@@ -21,7 +21,7 @@ describe('assertCanWithAudit — API-key scope gate', () => {
     const test = await createTestContext()
     ctx = test.ctx
     groupDb = test.groupDb
-    // The key acts as its issuing owner; seed that owner as a member.
+    // The key acts as its issuing member; seed that issuer as a member.
     await seedMember(groupDb, 'did:plc:owner', 'owner')
   })
 
@@ -41,7 +41,7 @@ describe('assertCanWithAudit — API-key scope gate', () => {
         undefined,
         apiKeyPrincipal([MEMBER_LIST_SCOPE]),
       ),
-    ).resolves.toBeUndefined()
+    ).resolves.toBe('owner')
   })
 
   it('denies (and audits) when the key lacks the required scope', async () => {
@@ -122,13 +122,13 @@ describe('assertCanWithAudit — API-key scope gate', () => {
       assertCanWithAudit(ctx, groupDb, 'did:plc:owner', 'member.list', undefined, {
         authKind: 'jwt',
       }),
-    ).resolves.toBeUndefined()
+    ).resolves.toBe('owner')
   })
 
   it('omitting the principal behaves like a JWT caller (back-compat)', async () => {
-    await expect(
-      assertCanWithAudit(ctx, groupDb, 'did:plc:owner', 'member.list'),
-    ).resolves.toBeUndefined()
+    await expect(assertCanWithAudit(ctx, groupDb, 'did:plc:owner', 'member.list')).resolves.toBe(
+      'owner',
+    )
   })
 
   // --- PDS-repo write ops gated by repo: scopes (collection+action) ---
@@ -146,7 +146,7 @@ describe('assertCanWithAudit — API-key scope gate', () => {
         detailFor(POST),
         apiKeyPrincipal([`repo:${POST}?action=create`]),
       ),
-    ).resolves.toBeUndefined()
+    ).resolves.toBe('owner')
   })
 
   it('denies createRecord on a collection the repo: scope does not cover', async () => {
@@ -205,9 +205,9 @@ describe('assertCanWithAudit — API-key scope gate', () => {
     const del = apiKeyPrincipal([`repo:${POST}?action=delete`])
     await expect(
       assertCanWithAudit(ctx, groupDb, 'did:plc:owner', 'deleteOwnRecord', detailFor(POST), del),
-    ).resolves.toBeUndefined()
+    ).resolves.toBe('owner')
     await expect(
       assertCanWithAudit(ctx, groupDb, 'did:plc:owner', 'deleteAnyRecord', detailFor(POST), del),
-    ).resolves.toBeUndefined()
+    ).resolves.toBe('owner')
   })
 })

--- a/tests/keys-create.test.ts
+++ b/tests/keys-create.test.ts
@@ -11,6 +11,7 @@ import type { GroupDatabase } from '../src/db/schema.js'
 
 const SERVICE_DID = 'did:web:test.example.com'
 const MEMBER_LIST_SCOPE = scopeNeededFor('member.list', SERVICE_DID)!
+const AUDIT_QUERY_SCOPE = scopeNeededFor('audit.query', SERVICE_DID)!
 
 function buildApp(ctx: AppContext) {
   return createTestApp(ctx, (server, appCtx) => keysCreateHandler(server, appCtx))
@@ -32,7 +33,7 @@ describe('keys.create', () => {
     await groupDb.destroy()
   })
 
-  it('owner mints a key; returns plaintext once and stores only the hash', async () => {
+  it('member mints a key; returns plaintext once and stores only the hash', async () => {
     await seedMember(groupDb, 'did:plc:testuser', 'owner')
     const res = await request(app)
       .post('/xrpc/app.certified.group.keys.create')
@@ -73,8 +74,8 @@ describe('keys.create', () => {
       .selectFrom('group_api_keys')
       .select('scopes')
       .where('key_ref', '=', res.body.keyRef)
-      .executeTakeFirst()
-    expect(JSON.parse(row!.scopes)).toEqual([MEMBER_LIST_SCOPE])
+      .executeTakeFirstOrThrow()
+    expect(row.scopes).toBe(JSON.stringify([MEMBER_LIST_SCOPE]))
   })
 
   it('rejects a scope whose aud names a different service with InvalidScope', async () => {
@@ -87,12 +88,49 @@ describe('keys.create', () => {
     expect(res.body.error).toBe('InvalidScope')
   })
 
-  it('rejects a non-owner (admin) with Forbidden', async () => {
+  it('allows a non-owner member to mint their own key', async () => {
+    await seedMember(groupDb, 'did:plc:testuser', 'member')
+    const res = await request(app)
+      .post('/xrpc/app.certified.group.keys.create')
+      .send({ name: 'member backend', scopes: [MEMBER_LIST_SCOPE] })
+    expect(res.status).toBe(200)
+
+    const row = await groupDb
+      .selectFrom('group_api_keys')
+      .select(['created_by', 'name'])
+      .where('key_ref', '=', res.body.keyRef)
+      .executeTakeFirst()
+    expect(row).toMatchObject({ created_by: 'did:plc:testuser', name: 'member backend' })
+  })
+
+  it('rejects a member-created key with an admin-only audit.query scope', async () => {
+    await seedMember(groupDb, 'did:plc:testuser', 'member')
+    const res = await request(app)
+      .post('/xrpc/app.certified.group.keys.create')
+      .send({ name: 'too broad', scopes: [AUDIT_QUERY_SCOPE] })
+    expect(res.status).toBe(403)
+
+    const count = await groupDb
+      .selectFrom('group_api_keys')
+      .select(groupDb.fn.countAll().as('n'))
+      .executeTakeFirstOrThrow()
+    expect(Number(count.n)).toBe(0)
+  })
+
+  it('allows an admin-created key with an audit.query scope', async () => {
     await seedMember(groupDb, 'did:plc:testuser', 'admin')
     const res = await request(app)
       .post('/xrpc/app.certified.group.keys.create')
-      .send({ name: 'nope', scopes: [MEMBER_LIST_SCOPE] })
-    expect(res.status).toBe(403)
+      .send({ name: 'admin reporting', scopes: [AUDIT_QUERY_SCOPE] })
+    expect(res.status).toBe(200)
+
+    const row = await groupDb
+      .selectFrom('group_api_keys')
+      .select(['created_by', 'scopes'])
+      .where('key_ref', '=', res.body.keyRef)
+      .executeTakeFirstOrThrow()
+    expect(row.created_by).toBe('did:plc:testuser')
+    expect(row.scopes).toBe(JSON.stringify([AUDIT_QUERY_SCOPE]))
   })
 
   it('rejects an invalid scope string with InvalidScope', async () => {
@@ -138,6 +176,39 @@ describe('keys.create', () => {
     expect(res.status).toBe(403)
   })
 
+  it('rejects API-key callers before resolving include: permission sets', async () => {
+    await seedMember(groupDb, 'did:plc:owner', 'owner')
+    let resolverCalled = false
+    ctx.permissionSets = {
+      resolve: async () => {
+        resolverCalled = true
+        throw new Error('resolver should not be called')
+      },
+    } as unknown as AppContext['permissionSets']
+    ctx.authVerifier = {
+      ...mockAuth('did:plc:owner'),
+      xrpcAuth() {
+        return async () => ({
+          credentials: {
+            callerDid: 'did:plc:owner',
+            groupDid: 'did:plc:testgroup',
+            legacyAud: false,
+            authKind: 'apiKey',
+            scopes: [`rpc:*?aud=${SERVICE_DID}%23certified_group_service`],
+            apiKeyRef: 'ref1',
+          },
+        })
+      },
+    }
+
+    const res = await request(buildApp(ctx))
+      .post('/xrpc/app.certified.group.keys.create')
+      .send({ name: 'self-mint', scopes: ['include:org.hypercerts.authWrite'] })
+
+    expect(res.status).toBe(403)
+    expect(resolverCalled).toBe(false)
+  })
+
   it('expands an include:<nsid> permission set into the concrete stored scopes', async () => {
     await seedMember(groupDb, 'did:plc:testuser', 'owner')
     // Override the resolver to return a known permission set for the include:.
@@ -172,8 +243,8 @@ describe('keys.create', () => {
       .selectFrom('group_api_keys')
       .select('scopes')
       .where('key_ref', '=', res.body.keyRef)
-      .executeTakeFirst()
-    expect(row!.scopes).not.toContain('include:')
+      .executeTakeFirstOrThrow()
+    expect(row.scopes).not.toContain('include:')
   })
 
   it('returns 400 InvalidScope when an include: set cannot be resolved', async () => {
@@ -194,7 +265,7 @@ describe('keys.create', () => {
     const count = await groupDb
       .selectFrom('group_api_keys')
       .select(groupDb.fn.countAll().as('n'))
-      .executeTakeFirst()
-    expect(Number(count!.n)).toBe(0)
+      .executeTakeFirstOrThrow()
+    expect(Number(count.n)).toBe(0)
   })
 })

--- a/tests/keys-delete.test.ts
+++ b/tests/keys-delete.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import express from 'express'
 import request from 'supertest'
-import { createTestContext, seedMember, createTestApp } from './helpers/mock-server.js'
+import { createTestContext, seedMember, createTestApp, mockAuth } from './helpers/mock-server.js'
 import keysDeleteHandler from '../src/api/keys/delete.js'
 import { generateApiKey } from '../src/auth/api-key.js'
 import { scopeNeededFor } from '../src/auth/scopes.js'
@@ -9,13 +9,14 @@ import type { AppContext } from '../src/context.js'
 import type { Kysely } from 'kysely'
 import type { GroupDatabase } from '../src/db/schema.js'
 
-const SCOPE = scopeNeededFor('member.list', 'did:web:test.example.com')!
+const SERVICE_DID = 'did:web:test.example.com'
+const SCOPE = scopeNeededFor('member.list', SERVICE_DID)!
 
 function buildApp(ctx: AppContext) {
   return createTestApp(ctx, (server, appCtx) => keysDeleteHandler(server, appCtx))
 }
 
-async function seedKey(groupDb: Kysely<GroupDatabase>, name = 'k') {
+async function seedKey(groupDb: Kysely<GroupDatabase>, name = 'k', createdBy = 'did:plc:owner') {
   const key = generateApiKey()
   await groupDb
     .insertInto('group_api_keys')
@@ -24,7 +25,7 @@ async function seedKey(groupDb: Kysely<GroupDatabase>, name = 'k') {
       key_hash: key.hash,
       name,
       scopes: JSON.stringify([SCOPE]),
-      created_by: 'did:plc:owner',
+      created_by: createdBy,
     })
     .execute()
   return key
@@ -84,17 +85,61 @@ describe('keys.delete', () => {
     expect(second.body.revokedAt).toBe(first.body.revokedAt)
   })
 
-  it('rejects a non-owner (admin) with Forbidden', async () => {
+  it('allows a non-owner member to revoke their own key', async () => {
     const test = await createTestContext()
-    const adminDb = test.groupDb
-    await seedMember(adminDb, 'did:plc:testuser', 'admin')
-    const key = await seedKey(adminDb)
-    const adminApp = buildApp(test.ctx)
-    const res = await request(adminApp)
+    const memberDb = test.groupDb
+    await seedMember(memberDb, 'did:plc:testuser', 'member')
+    const key = await seedKey(memberDb, 'mine', 'did:plc:testuser')
+    const memberApp = buildApp(test.ctx)
+    const res = await request(memberApp)
+      .post('/xrpc/app.certified.group.keys.delete')
+      .send({ keyRef: key.keyRef })
+    expect(res.status).toBe(200)
+    await memberDb.destroy()
+  })
+
+  it('rejects a non-owner member revoking someone else’s key', async () => {
+    const test = await createTestContext()
+    const memberDb = test.groupDb
+    await seedMember(memberDb, 'did:plc:testuser', 'admin')
+    const key = await seedKey(memberDb, 'not-mine', 'did:plc:owner')
+    const memberApp = buildApp(test.ctx)
+    const res = await request(memberApp)
       .post('/xrpc/app.certified.group.keys.delete')
       .send({ keyRef: key.keyRef })
     expect(res.status).toBe(403)
-    await adminDb.destroy()
+    await memberDb.destroy()
+  })
+
+  it('owner can revoke another member’s key', async () => {
+    const key = await seedKey(groupDb, 'member-key', 'did:plc:member')
+    const res = await request(app)
+      .post('/xrpc/app.certified.group.keys.delete')
+      .send({ keyRef: key.keyRef })
+    expect(res.status).toBe(200)
+  })
+
+  it('an API-key caller cannot revoke keys', async () => {
+    const key = await seedKey(groupDb, 'mine', 'did:plc:testuser')
+    ctx.authVerifier = {
+      ...mockAuth('did:plc:testuser'),
+      xrpcAuth() {
+        return async () => ({
+          credentials: {
+            callerDid: 'did:plc:testuser',
+            groupDid: 'did:plc:testgroup',
+            legacyAud: false,
+            authKind: 'apiKey',
+            scopes: [`rpc:*?aud=${SERVICE_DID}%23certified_group_service`],
+            apiKeyRef: 'ref1',
+          },
+        })
+      },
+    }
+    const res = await request(buildApp(ctx))
+      .post('/xrpc/app.certified.group.keys.delete')
+      .send({ keyRef: key.keyRef })
+    expect(res.status).toBe(403)
   })
 
   it('an empty/missing body is a 400, not a 500', async () => {

--- a/tests/keys-list.test.ts
+++ b/tests/keys-list.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import express from 'express'
 import request from 'supertest'
-import { createTestContext, seedMember, createTestApp } from './helpers/mock-server.js'
+import { createTestContext, seedMember, createTestApp, mockAuth } from './helpers/mock-server.js'
 import keysListHandler from '../src/api/keys/list.js'
 import { generateApiKey } from '../src/auth/api-key.js'
 import { scopeNeededFor } from '../src/auth/scopes.js'
@@ -19,7 +19,7 @@ function buildApp(ctx: AppContext) {
 async function seedKey(
   groupDb: Kysely<GroupDatabase>,
   name: string,
-  opts: { revoked?: boolean } = {},
+  opts: { createdBy?: string; revoked?: boolean } = {},
 ) {
   const key = generateApiKey()
   await groupDb
@@ -29,7 +29,7 @@ async function seedKey(
       key_hash: key.hash,
       name,
       scopes: JSON.stringify([SCOPE]),
-      created_by: 'did:plc:owner',
+      created_by: opts.createdBy ?? 'did:plc:owner',
       revoked_at: opts.revoked ? '2020-01-01 00:00:00' : null,
     })
     .execute()
@@ -104,13 +104,45 @@ describe('keys.list', () => {
     expect(refs.size).toBe(3)
   })
 
-  it('rejects a non-owner (admin) with Forbidden', async () => {
+  it('non-owner members list only their own keys', async () => {
     const test = await createTestContext()
-    const adminGroupDb = test.groupDb
-    await seedMember(adminGroupDb, 'did:plc:testuser', 'admin')
-    const adminApp = buildApp(test.ctx)
-    const res = await request(adminApp).get('/xrpc/app.certified.group.keys.list')
+    const memberGroupDb = test.groupDb
+    await seedMember(memberGroupDb, 'did:plc:testuser', 'member')
+    await seedKey(memberGroupDb, 'mine-a', { createdBy: 'did:plc:testuser' })
+    await seedKey(memberGroupDb, 'mine-revoked', { createdBy: 'did:plc:testuser', revoked: true })
+    await seedKey(memberGroupDb, 'someone-else', { createdBy: 'did:plc:owner' })
+    const memberApp = buildApp(test.ctx)
+
+    const active = await request(memberApp).get('/xrpc/app.certified.group.keys.list')
+    expect(active.status).toBe(200)
+    expect(active.body.keys.map((k: { name: string }) => k.name)).toEqual(['mine-a'])
+
+    const all = await request(memberApp).get(
+      '/xrpc/app.certified.group.keys.list?includeRevoked=true',
+    )
+    const names = all.body.keys.map((k: { name: string }) => k.name).sort()
+    expect(names).toEqual(['mine-a', 'mine-revoked'])
+    await memberGroupDb.destroy()
+  })
+
+  it('an API-key caller cannot list keys', async () => {
+    await seedKey(groupDb, 'mine', { createdBy: 'did:plc:testuser' })
+    ctx.authVerifier = {
+      ...mockAuth('did:plc:testuser'),
+      xrpcAuth() {
+        return async () => ({
+          credentials: {
+            callerDid: 'did:plc:testuser',
+            groupDid: 'did:plc:testgroup',
+            legacyAud: false,
+            authKind: 'apiKey',
+            scopes: [`rpc:*?aud=${SERVICE_DID}%23certified_group_service`],
+            apiKeyRef: 'ref1',
+          },
+        })
+      },
+    }
+    const res = await request(buildApp(ctx)).get('/xrpc/app.certified.group.keys.list')
     expect(res.status).toBe(403)
-    await adminGroupDb.destroy()
   })
 })

--- a/tests/rbac.test.ts
+++ b/tests/rbac.test.ts
@@ -18,6 +18,9 @@ describe('canPerform', () => {
     'deleteOwnRecord',
     'putOwnRecord',
     'member.list',
+    'keys.create',
+    'keys.list',
+    'keys.delete',
   ]
   const adminOps: Operation[] = [
     'putAnyRecord',
@@ -27,7 +30,7 @@ describe('canPerform', () => {
     'member.remove',
     'audit.query',
   ]
-  const ownerOps: Operation[] = ['role.set']
+  const ownerOps: Operation[] = ['role.set', 'group.destroy']
 
   it('member can perform member-level ops', () => {
     for (const op of memberOps) expect(canPerform('member', op)).toBe(true)
@@ -128,13 +131,16 @@ describe('RBAC constants', () => {
     expect(ROLE_HIERARCHY.admin).toBeLessThan(ROLE_HIERARCHY.owner)
   })
 
-  it('canPerform covers all 12 operations', () => {
+  it('canPerform covers all operations', () => {
     const allOps: Operation[] = [
       'createRecord',
       'uploadBlob',
       'deleteOwnRecord',
       'putOwnRecord',
       'member.list',
+      'keys.create',
+      'keys.list',
+      'keys.delete',
       'putAnyRecord',
       'deleteAnyRecord',
       'putRecord:profile',
@@ -142,15 +148,16 @@ describe('RBAC constants', () => {
       'member.remove',
       'audit.query',
       'role.set',
+      'group.destroy',
     ]
-    // member: 5 ops
+    // member: 8 ops
     const memberOps = allOps.filter((op) => canPerform('member', op))
-    expect(memberOps).toHaveLength(5)
-    // admin: 11 ops
+    expect(memberOps).toHaveLength(8)
+    // admin: 14 ops
     const adminOps = allOps.filter((op) => canPerform('admin', op))
-    expect(adminOps).toHaveLength(11)
-    // owner: all 12
+    expect(adminOps).toHaveLength(14)
+    // owner: all 16
     const ownerOps = allOps.filter((op) => canPerform('owner', op))
-    expect(ownerOps).toHaveLength(12)
+    expect(ownerOps).toHaveLength(16)
   })
 })

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -12,8 +12,12 @@ import {
   repoActionForOperation,
   repoScopesCover,
   blobScopesCover,
+  validateScopesAllowedForRole,
 } from '../src/auth/scopes.js'
-import type { PermissionSetResolver } from '../src/auth/permission-set-resolver.js'
+import {
+  PermissionSetResolutionError,
+  type PermissionSetResolver,
+} from '../src/auth/permission-set-resolver.js'
 
 const SERVICE_DID = 'did:web:groups.example.com'
 
@@ -42,6 +46,7 @@ const HYPERCERTS_SET = {
 // The package URL-encodes `#` as `%23` in the emitted scope string; use its own
 // output as the canonical form rather than hand-writing the encoding.
 const MEMBER_LIST_SCOPE = scopeNeededFor('member.list', SERVICE_DID)!
+const AUDIT_QUERY_SCOPE = scopeNeededFor('audit.query', SERVICE_DID)!
 
 describe('serviceScopeAud', () => {
   it('appends the service-id fragment to the bare DID', () => {
@@ -102,6 +107,51 @@ describe('scopesCoverOperation', () => {
   it('denies when the scope aud is for a different service', () => {
     const otherAud = scopeNeededFor('member.list', 'did:web:evil.example.com')!
     expect(scopesCoverOperation([otherAud], 'member.list', SERVICE_DID)).toBe(false)
+  })
+})
+
+describe('validateScopesAllowedForRole', () => {
+  it('allows member-level rpc scopes for members', () => {
+    expect(validateScopesAllowedForRole([MEMBER_LIST_SCOPE], 'member')).toEqual({ ok: true })
+  })
+
+  it('rejects admin-level rpc scopes for members', () => {
+    const result = validateScopesAllowedForRole([AUDIT_QUERY_SCOPE], 'member')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toContain("role 'member' cannot use scope")
+  })
+
+  it('allows admin-level rpc scopes for admins', () => {
+    expect(validateScopesAllowedForRole([AUDIT_QUERY_SCOPE], 'admin')).toEqual({ ok: true })
+  })
+
+  it('validates wildcard rpc scopes against every key-accessible rpc operation', () => {
+    const wild = `rpc:*?aud=${serviceScopeAud(SERVICE_DID)}`
+    const memberResult = validateScopesAllowedForRole([wild], 'member')
+    expect(memberResult.ok).toBe(false)
+    if (!memberResult.ok) expect(memberResult.reason).toContain('audit.query')
+    expect(validateScopesAllowedForRole([wild], 'admin')).toEqual({ ok: true })
+  })
+
+  it('allows blob scopes for members', () => {
+    expect(validateScopesAllowedForRole(['blob:image/*'], 'member')).toEqual({ ok: true })
+  })
+
+  it('rejects unsupported scope kinds', () => {
+    const result = validateScopesAllowedForRole(['account:email?action=read'], 'owner')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toContain('unsupported scope kind')
+  })
+
+  it('rejects unknown rpc methods because no key-accessible operation uses them', () => {
+    const scope = `rpc:app.certified.group.noop?aud=${serviceScopeAud(SERVICE_DID)}`
+    const result = validateScopesAllowedForRole([scope], 'owner')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toContain('not key-accessible')
+  })
+
+  it('allows repo scopes for members because own-vs-any is enforced at request time', () => {
+    expect(validateScopesAllowedForRole([REPO_CREATE], 'member')).toEqual({ ok: true })
   })
 })
 
@@ -314,6 +364,28 @@ describe('expandIncludes', () => {
     if (res.ok) return
     expect(res.scope).toBe('include:org.unknown.authWrite')
     expect(res.reason).toMatch(/unknown set/)
+  })
+
+  it('preserves PermissionSetResolutionError reasons', async () => {
+    const errorResolver = {
+      resolve: async () => {
+        throw new PermissionSetResolutionError('org.bad.authWrite', 'bad TXT record')
+      },
+    } as unknown as PermissionSetResolver
+    const res = await expandIncludes(['include:org.bad.authWrite'], SERVICE_DID, errorResolver)
+    expect(res).toEqual({ ok: false, scope: 'include:org.bad.authWrite', reason: 'bad TXT record' })
+  })
+
+  it('rejects permission sets that expand to no scopes', async () => {
+    const emptyResolver = fakeResolver({
+      'org.empty.authWrite': { type: 'permission-set', permissions: [] },
+    })
+    const res = await expandIncludes(['include:org.empty.authWrite'], SERVICE_DID, emptyResolver)
+    expect(res).toEqual({
+      ok: false,
+      scope: 'include:org.empty.authWrite',
+      reason: 'permission set expanded to no scopes',
+    })
   })
 
   it('the expanded scopes pass canonicalizeScopes', async () => {

--- a/tests/verifier.test.ts
+++ b/tests/verifier.test.ts
@@ -442,7 +442,7 @@ describe('AuthVerifier', () => {
       const key = await seedKey()
       const { credentials } = await runAuth(apiKeyReq(key.plaintext))
       expect(credentials).toMatchObject({
-        callerDid: 'did:plc:owner', // issuing owner DID
+        callerDid: 'did:plc:owner', // issuing member DID
         groupDid: GROUP,
         legacyAud: false,
         authKind: 'apiKey',


### PR DESCRIPTION
## Summary

- Allow any group member to create API keys for themselves
- Let non-owner members list/revoke only their own keys while owners retain group-wide visibility/revocation
- Keep key management JWT-only; API-key auth still cannot create/list/revoke keys
- Update docs, lexicons, tests, and changeset for the new policy

Closes #57

## Validation

- pnpm format:check
- pnpm typecheck
- pnpm lint
- pnpm test
- ubs <changed-files> (0 critical issues)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group members can now independently create, list, and revoke long-lived API keys for their own access (owners still can list/revoke any key).
  * Key issuance/management is now fully member-scoped, with JWT-only key-management operations.

* **Changes**
  * API keys act on behalf of the member who issued the key, with permissions effectively enforced as `key scopes ∩ issuing member role`.
  * Member role changes and removed issuers are reflected immediately (including denial for previously valid keys).

* **Documentation & Tests**
  * Updated API/design/lexicon docs and expanded scope, authorization, and end-to-end test coverage to match the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->