### PR TITLE
fix(changeset): add audience for member API keys

### DIFF
--- a/.changeset/member-api-keys.md
+++ b/.changeset/member-api-keys.md
@@ -5,3 +5,5 @@
 Allow all group members to create, list, and revoke their own API keys. Owners
 retain group-wide visibility and revocation, while API-key auth itself still
 cannot manage keys.
+
+**Affects:** Client app developers


### PR DESCRIPTION
## Summary

- Add the required `**Affects:**` audience line to the member API keys changeset so `scripts/changelog-audience-summary.mjs` can generate release notes.

## Validation

- `pnpm exec prettier --check .changeset/member-api-keys.md`
- `git diff --check`

Fixes the failed release workflow: https://github.com/hypercerts-org/certified-group-service/actions/runs/28101669075/job/83205028236
