### PR TITLE
feat(demo): "my groups" picker driven by membership.list

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gpds-demo",
+  "name": "cgs-demo",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/demo/server/oauth/proxy-agent.ts
+++ b/demo/server/oauth/proxy-agent.ts
@@ -64,10 +64,16 @@ function requireServiceDid(): string {
  * service-entry PLC op. A direct call resolves the group from the `repo`
  * param (querystring for queries, body for procedures) and never touches PDS
  * DID-document caching.
+ *
+ * `groupDid` is optional: service-level methods (e.g. groups.membership.list,
+ * which lists the caller's own groups) name no target group. When it is
+ * undefined, no `repo` is sent — the service resolves the caller from the JWT
+ * `iss` alone. When present, `repo` is forced LAST so caller-supplied
+ * params/body can never override the routing target.
  */
 export async function callGroupService(
   userDid: string,
-  groupDid: string,
+  groupDid: string | undefined,
   nsid: string,
   opts: { method: 'GET' | 'POST'; params?: Record<string, string>; body?: Record<string, unknown> },
 ): Promise<GroupServiceResult> {
@@ -78,12 +84,13 @@ export async function callGroupService(
   // Prove the caller controls userDid; aud = service DID, lxm = the method.
   const serviceAuth = await agent.com.atproto.server.getServiceAuth({ aud, lxm: nsid })
 
-  // The group is always identified by `repo`: querystring for queries, body for
+  // The group is identified by `repo`: querystring for queries, body for
   // procedures (matches the group service's verifier, which reads repo before
-  // the body is parsed for queries). Force repo = groupDid LAST so a caller's
-  // params/body can never override the routing target.
-  const query = new URLSearchParams({ ...(opts.params ?? {}), repo: groupDid }).toString()
-  const url = `${GROUP_SERVICE_URL.replace(/\/$/, '')}/xrpc/${nsid}?${query}`
+  // the body is parsed for queries). Omitted for service-level methods.
+  const params = new URLSearchParams(opts.params ?? {})
+  if (groupDid) params.set('repo', groupDid) // forced last — wins over caller params
+  const query = params.toString()
+  const url = `${GROUP_SERVICE_URL.replace(/\/$/, '')}/xrpc/${nsid}${query ? `?${query}` : ''}`
 
   const headers: Record<string, string> = { Authorization: `Bearer ${serviceAuth.data.token}` }
   let requestBody: string | undefined
@@ -92,7 +99,7 @@ export async function callGroupService(
     // Include repo in the body too so procedure handlers that read input.body.repo
     // resolve the same group (the confused-deputy guard requires body == querystring).
     // repo is forced last so a caller-supplied repo cannot override groupDid.
-    requestBody = JSON.stringify({ ...(opts.body ?? {}), repo: groupDid })
+    requestBody = JSON.stringify(groupDid ? { ...(opts.body ?? {}), repo: groupDid } : (opts.body ?? {}))
   }
 
   return fetchUpstream(url, { method: opts.method, headers, body: requestBody })

--- a/demo/server/routes/proxy.ts
+++ b/demo/server/routes/proxy.ts
@@ -4,6 +4,11 @@ import { callGroupService, isSessionExpiredError } from '../oauth/proxy-agent.js
 
 const router = Router()
 
+// Service-level methods name no target group — the group service resolves the
+// caller from the JWT `iss` alone. Every other method must carry a `groupDid`,
+// so a forgotten target is caught here rather than failing deeper upstream.
+const GROUPLESS_METHODS = new Set(['app.certified.groups.membership.list'])
+
 function handleProxyError(res: Response, err: any) {
   if (isSessionExpiredError(err)) {
     return res
@@ -29,7 +34,7 @@ router.post('/:nsid', async (req, res) => {
     const { nsid } = req.params
     const { groupDid, ...body } = req.body
 
-    if (!groupDid) {
+    if (!groupDid && !GROUPLESS_METHODS.has(nsid)) {
       return res.status(400).json({ error: 'Missing groupDid' })
     }
 
@@ -56,7 +61,7 @@ router.get('/:nsid', async (req, res) => {
     const { nsid } = req.params
     const { groupDid, ...params } = req.query as Record<string, string>
 
-    if (!groupDid) {
+    if (!groupDid && !GROUPLESS_METHODS.has(nsid)) {
       return res.status(400).json({ error: 'Missing groupDid query param' })
     }
 

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -51,28 +51,12 @@ export function App() {
   const [user, setUser] = useState<AuthUser | null>(null)
   const [loading, setLoading] = useState(true)
 
-  // Restore active group from localStorage
-  const [group, setGroupState] = useState<ActiveGroup | null>(() => {
-    const stored = localStorage.getItem('activeGroup')
-    if (stored) {
-      try { return JSON.parse(stored) } catch { /* ignore */ }
-    }
-    // Migrate from old groupDid-only storage
-    const legacyDid = localStorage.getItem('groupDid')
-    if (legacyDid) return { did: legacyDid, handle: '' }
-    return null
-  })
-
-  const setGroup = (g: ActiveGroup | null) => {
-    setGroupState(g)
-    if (g) {
-      localStorage.setItem('activeGroup', JSON.stringify(g))
-      localStorage.setItem('groupDid', g.did) // keep legacy key in sync
-    } else {
-      localStorage.removeItem('activeGroup')
-      localStorage.removeItem('groupDid')
-    }
-  }
+  // The active group is session-only: not persisted. It is derived each load
+  // from the user's memberships (auto-selected when there is exactly one,
+  // chosen via the picker otherwise — see Layout). Persisting it in
+  // localStorage was origin-scoped, not per-user, so it leaked one user's
+  // selection to the next user on a shared browser.
+  const [group, setGroup] = useState<ActiveGroup | null>(null)
 
   useEffect(() => {
     // When any API call gets a 401, clear auth state so the user is redirected to login
@@ -84,9 +68,9 @@ export function App() {
       .finally(() => setLoading(false))
   }, [])
 
-  // Backfill the active group's handle when it is missing — e.g. the group was
-  // entered as a raw DID, or restored from legacy DID-only storage. Reverse-
-  // resolving here means every consumer (banner, page headers) gets the
+  // Backfill the active group's handle when it is missing — e.g. a group
+  // auto-selected (or picked) before its handle had finished resolving.
+  // Reverse-resolving here means every consumer (banner, page headers) gets the
   // human-readable handle without each having to resolve it. Best-effort: on
   // failure the DID simply remains the display value.
   useEffect(() => {

--- a/demo/src/api.ts
+++ b/demo/src/api.ts
@@ -82,6 +82,36 @@ export const proxyGet = (nsid: string, params: Record<string, string>) => {
   return request(`/proxy/${nsid}?${qs}`)
 }
 
+// --- My groups ---
+// The groups the logged-in user belongs to. This is the one group-service call
+// that names no target group: the service scopes it to the caller's own DID
+// (from the service-auth JWT `iss`), so no `groupDid` is sent.
+
+export interface MyGroup {
+  groupDid: string
+  role: string
+  joinedAt: string
+}
+
+/**
+ * List the caller's group memberships, following the cursor to return every
+ * page. The demo's group counts are small, so eager pagination keeps callers
+ * simple; revisit if a user can belong to hundreds of groups.
+ */
+export const listMyGroups = async (): Promise<MyGroup[]> => {
+  const out: MyGroup[] = []
+  let cursor: string | undefined
+  do {
+    const res: { groups: MyGroup[]; cursor?: string } = await proxyGet(
+      'app.certified.groups.membership.list',
+      cursor ? { cursor } : {},
+    )
+    out.push(...(res.groups ?? []))
+    cursor = res.cursor
+  } while (cursor)
+  return out
+}
+
 // --- API keys ---
 // Management (create / list / delete) is owner-authed, so it goes through the
 // normal atproto-proxy BFF route like any other group XRPC method.

--- a/demo/src/components/Layout.tsx
+++ b/demo/src/components/Layout.tsx
@@ -78,17 +78,17 @@ export function Layout() {
     // freshly-registered group should appear in the list without a reload).
   }, [user, group?.did])
 
-  // Auto-select so the user is never staring at an empty picker when they do
-  // have groups: pick the first when nothing is active, or when the restored
-  // group is one they're no longer a member of. Keying on the membership set
-  // (not array identity) keeps this idempotent across re-renders.
+  // Auto-select ONLY when the user has exactly one group — there is no choice
+  // to make, so picking it for them saves a click. With more than one group we
+  // leave the picker on its placeholder so the user consciously chooses (and
+  // doesn't silently land on whichever happens to be first). Keying on the
+  // membership set keeps this idempotent across re-renders.
   const groupKey = myGroups.map((g) => g.groupDid).join(',')
   useEffect(() => {
-    if (myGroups.length === 0) return
-    const stillMember = group && myGroups.some((g) => g.groupDid === group.did)
-    if (stillMember) return
-    const first = myGroups[0]
-    setGroup({ did: first.groupDid, handle: handles[first.groupDid] ?? '' })
+    if (myGroups.length !== 1) return
+    const only = myGroups[0]
+    if (group?.did === only.groupDid) return
+    setGroup({ did: only.groupDid, handle: handles[only.groupDid] ?? '' })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [groupKey])
 

--- a/demo/src/components/Layout.tsx
+++ b/demo/src/components/Layout.tsx
@@ -66,10 +66,19 @@ export function Layout() {
     setGroupsError('')
     listMyGroups()
       .then((groups) => {
-        if (!cancelled) setMyGroups(groups)
+        if (cancelled) return
+        setMyGroups(groups)
+        // Drop an active group that isn't in the caller's memberships — e.g. a
+        // different user logged in on this session, or the group is gone. Stops
+        // later requests targeting a group the caller can't act on.
+        if (group && !groups.some((g) => g.groupDid === group.did)) setGroup(null)
       })
       .catch((err: any) => {
-        if (!cancelled) setGroupsError(err.message)
+        if (cancelled) return
+        setGroupsError(err.message)
+        // Membership unknown — don't keep targeting a possibly-stale group.
+        setMyGroups([])
+        setGroup(null)
       })
     return () => {
       cancelled = true
@@ -95,6 +104,7 @@ export function Layout() {
   const handleLogout = async () => {
     await logout()
     setUser(null)
+    setGroup(null) // don't carry the active group into the next user's session
     navigate('/login')
   }
 

--- a/demo/src/components/Layout.tsx
+++ b/demo/src/components/Layout.tsx
@@ -3,7 +3,6 @@ import { Outlet, Link, useNavigate } from 'react-router-dom'
 import { useAuth, useGroup } from '../App'
 import { logout, listMyGroups, type MyGroup } from '../api'
 import { CopyDid } from './CopyDid'
-import { HandleId } from './HandleId'
 import { useHandles } from '../useHandles'
 
 const styles = {
@@ -79,6 +78,20 @@ export function Layout() {
     // freshly-registered group should appear in the list without a reload).
   }, [user, group?.did])
 
+  // Auto-select so the user is never staring at an empty picker when they do
+  // have groups: pick the first when nothing is active, or when the restored
+  // group is one they're no longer a member of. Keying on the membership set
+  // (not array identity) keeps this idempotent across re-renders.
+  const groupKey = myGroups.map((g) => g.groupDid).join(',')
+  useEffect(() => {
+    if (myGroups.length === 0) return
+    const stillMember = group && myGroups.some((g) => g.groupDid === group.did)
+    if (stillMember) return
+    const first = myGroups[0]
+    setGroup({ did: first.groupDid, handle: handles[first.groupDid] ?? '' })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupKey])
+
   const handleLogout = async () => {
     await logout()
     setUser(null)
@@ -134,7 +147,7 @@ export function Layout() {
             value={group?.did ?? ''}
             onChange={(e) => selectGroup(e.target.value)}
           >
-            <option value="">— none —</option>
+            <option value="">— Select a group —</option>
             {myGroups.map((g) => {
               const handle = handles[g.groupDid]
               const label = handle ? `${handle} (${g.role})` : `${g.groupDid} (${g.role})`
@@ -145,15 +158,6 @@ export function Layout() {
               )
             })}
           </select>
-
-          {group && (
-            <HandleId
-              did={group.did}
-              handle={group.handle}
-              layout="inline"
-              style={{ fontSize: 12, background: '#fff', padding: '2px 8px', borderRadius: 4 }}
-            />
-          )}
 
           {myGroups.length === 0 && !groupsError && (
             <>

--- a/demo/src/components/Layout.tsx
+++ b/demo/src/components/Layout.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Outlet, Link, useNavigate } from 'react-router-dom'
 import { useAuth, useGroup } from '../App'
-import { logout, resolveIdentifier } from '../api'
+import { logout, listMyGroups, type MyGroup } from '../api'
 import { CopyDid } from './CopyDid'
 import { HandleId } from './HandleId'
+import { useHandles } from '../useHandles'
 
 const styles = {
   nav: {
@@ -33,15 +34,50 @@ const styles = {
     borderRadius: 4,
     fontSize: 13,
   } as React.CSSProperties,
+  select: {
+    padding: '3px 8px',
+    border: '1px solid #90a4ae',
+    borderRadius: 4,
+    fontSize: 12,
+    maxWidth: 360,
+  } as React.CSSProperties,
 }
 
 export function Layout() {
   const { user, setUser } = useAuth()
   const { group, setGroup } = useGroup()
   const navigate = useNavigate()
-  const [showGroupInput, setShowGroupInput] = useState(false)
-  const [didInput, setDidInput] = useState('')
-  const [didInputError, setDidInputError] = useState('')
+
+  // The groups the logged-in user belongs to, for the active-group picker. The
+  // demo can only operate on groups the caller is a member of (member.list and
+  // friends are member-gated), so this list IS the full set of usable groups —
+  // there is no value in a free-form "any DID" entry.
+  const [myGroups, setMyGroups] = useState<MyGroup[]>([])
+  const [groupsError, setGroupsError] = useState('')
+
+  // Reverse-resolve group DIDs so the picker can lead with handles.
+  const handles = useHandles(myGroups.map((g) => g.groupDid))
+
+  useEffect(() => {
+    if (!user) {
+      setMyGroups([])
+      return
+    }
+    let cancelled = false
+    setGroupsError('')
+    listMyGroups()
+      .then((groups) => {
+        if (!cancelled) setMyGroups(groups)
+      })
+      .catch((err: any) => {
+        if (!cancelled) setGroupsError(err.message)
+      })
+    return () => {
+      cancelled = true
+    }
+    // Re-fetch when the user changes, or after the active group changes (a
+    // freshly-registered group should appear in the list without a reload).
+  }, [user, group?.did])
 
   const handleLogout = async () => {
     await logout()
@@ -49,19 +85,15 @@ export function Layout() {
     navigate('/login')
   }
 
-  const handleSetGroupDid = async () => {
-    const value = didInput.trim()
-    if (!value) return
-    setDidInputError('')
-    try {
-      // Accept a DID or a handle.
-      const { did, handle } = await resolveIdentifier(value)
-      setGroup({ did, handle: handle ?? '' })
-      setDidInput('')
-      setShowGroupInput(false)
-    } catch (err: any) {
-      setDidInputError(err.message)
+  const selectGroup = (did: string) => {
+    if (!did) {
+      setGroup(null)
+      return
     }
+    const handle = handles[did]
+    // Empty handle is fine — HandleId falls back to the DID and the Dashboard
+    // re-resolves the handle on load.
+    setGroup({ did, handle: handle ?? '' })
   }
 
   return (
@@ -94,69 +126,46 @@ export function Layout() {
           borderBottom: '1px solid #ddd',
           fontSize: 13,
         }}>
-          {group ? (
+          <span style={{ fontWeight: 600 }}>Active group:</span>
+
+          {/* Picker over the caller's own memberships. */}
+          <select
+            style={styles.select}
+            value={group?.did ?? ''}
+            onChange={(e) => selectGroup(e.target.value)}
+          >
+            <option value="">— none —</option>
+            {myGroups.map((g) => {
+              const handle = handles[g.groupDid]
+              const label = handle ? `${handle} (${g.role})` : `${g.groupDid} (${g.role})`
+              return (
+                <option key={g.groupDid} value={g.groupDid}>
+                  {label}
+                </option>
+              )
+            })}
+          </select>
+
+          {group && (
+            <HandleId
+              did={group.did}
+              handle={group.handle}
+              layout="inline"
+              style={{ fontSize: 12, background: '#fff', padding: '2px 8px', borderRadius: 4 }}
+            />
+          )}
+
+          {myGroups.length === 0 && !groupsError && (
             <>
-              <span style={{ fontWeight: 600 }}>Active group:</span>
-              <HandleId
-                did={group.did}
-                handle={group.handle}
-                layout="inline"
-                style={{ fontSize: 12, background: '#fff', padding: '2px 8px', borderRadius: 4 }}
-              />
-              <button
-                onClick={() => setShowGroupInput(!showGroupInput)}
-                style={{ ...styles.btn, color: '#1a1a2e', borderColor: '#90a4ae', fontSize: 12, padding: '2px 8px' }}
-              >
-                Switch
-              </button>
-              <button
-                onClick={() => setGroup(null)}
-                style={{ ...styles.btn, color: '#e74c3c', borderColor: '#e74c3c', fontSize: 12, padding: '2px 8px' }}
-              >
-                Clear
-              </button>
-            </>
-          ) : (
-            <>
-              <span style={{ color: '#e65100' }}>No group selected.</span>
+              <span style={{ color: '#e65100' }}>You are not in any groups yet.</span>
               <Link to="/register" style={{ color: '#1565c0', fontWeight: 600, textDecoration: 'none' }}>
                 Register a new group
               </Link>
-              <span style={{ color: '#999' }}>or</span>
-              <button
-                onClick={() => setShowGroupInput(!showGroupInput)}
-                style={{ ...styles.btn, color: '#1a1a2e', borderColor: '#90a4ae', fontSize: 12, padding: '2px 8px' }}
-              >
-                Enter Group DID
-              </button>
             </>
           )}
-          {showGroupInput && (
-            <div style={{ display: 'flex', gap: 4, marginLeft: 8, alignItems: 'center' }}>
-              <input
-                style={{
-                  padding: '3px 8px',
-                  border: '1px solid #ccc',
-                  borderRadius: 4,
-                  fontSize: 12,
-                  width: 280,
-                }}
-                value={didInput}
-                onChange={(e) => setDidInput(e.target.value)}
-                placeholder="Group DID or handle"
-                onKeyDown={(e) => e.key === 'Enter' && handleSetGroupDid()}
-                autoFocus
-              />
-              <button
-                onClick={handleSetGroupDid}
-                style={{ ...styles.btn, color: '#1a1a2e', borderColor: '#1a1a2e', fontSize: 12, padding: '2px 8px' }}
-              >
-                Set
-              </button>
-              {didInputError && (
-                <span style={{ color: '#c0392b', fontSize: 11 }}>{didInputError}</span>
-              )}
-            </div>
+
+          {groupsError && (
+            <span style={{ color: '#c0392b', fontSize: 11 }}>Couldn’t load your groups: {groupsError}</span>
           )}
         </div>
       )}


### PR DESCRIPTION
## What

Replaces the manual group-DID/handle entry in the demo's active-group bar with a **dropdown of the groups the logged-in user actually belongs to**, fetched from `app.certified.groups.membership.list`.

Answers the original question — *"does the demo query to find all groups the user is in?"* It didn't; now it does.

## Why

The manual entry never added value: every group-scoped demo call (`member.list`, etc.) is **member-gated**, so a group you aren't in was already unusable (`Forbidden`). `membership.list` is the purpose-built reverse lookup — caller-scoped via the service-auth JWT `iss`, backed by the global `member_index` table — so the demo can show exactly the set of groups it can operate on.

## Changes (demo only — no service/API/RBAC change)

- **`src/api.ts`** — `listMyGroups()` helper; follows the cursor to return all pages.
- **`server/oauth/proxy-agent.ts`** — `callGroupService` `groupDid` is now optional. Service-level methods send **no `repo`** (the service resolves the caller from `iss` alone); when present, `repo` is still forced last so caller params can't override the routing target.
- **`server/routes/proxy.ts`** — `GROUPLESS_METHODS` allowlist lets only known group-less methods omit `groupDid`; every other call still requires a target, so a forgotten group is caught early rather than failing deep upstream.
- **`src/components/Layout.tsx`** — dropdown reverse-resolves group DIDs → handles for labels (reusing `useHandles`); falls back to a "register a group" prompt when the user has no memberships.

Also a drive-by: **renames the demo package `gpds-demo` → `cgs-demo`** (separate commit) — "GPDS" is a forbidden term per `AGENTS.md` terminology.

## Server side

**No server change needed.** `membership.list` already exists, is service-aud, caller-scoped, and paginated.

## Testing

- `tsc --noEmit` clean (client + server tsconfigs)
- `pnpm test` (demo): 16 passed
- `prettier --check` clean on changed files
- No changeset: demo-only change, nothing for service consumers to adapt to.

⚠️ **Not yet run end-to-end against a live CGS** (OAuth needs a publicly-fetchable client-metadata URL). Reviewer/author to configure this PR's preview against the chosen CGS instance (e.g. `test.groups.certified.app`) to exercise the live login + picker flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “My groups” view that lists the groups you belong to.
  * Replaced manual group entry with a dropdown for selecting the active group.
  * Improved group selection to automatically keep or pick a valid group when your memberships change.

* **Bug Fixes**
  * Better support for actions that don’t require choosing a group first.
  * Improved handling of empty group lists and fetch errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->