### PR TITLE
ci(release): pin Node to 22.22.3 (node-fetch keep-alive regression)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,14 @@ jobs:
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 22
+          # Pinned to 22.22.3: Node 22.23.0 (and 24.17.0) regressed http.Agent
+          # keep-alive socket reuse (nodejs/node#63989), which makes node-fetch@2
+          # — used by @changesets/get-github-info for the GitHub GraphQL call in
+          # the release step below — throw ERR_STREAM_PREMATURE_CLOSE. The
+          # ubuntu-latest image 20260622 bumped cached Node 22.22.3 -> 22.23.0,
+          # which is exactly when releases started failing. Unpin once a fixed
+          # 22.23.x ships.
+          node-version: 22.22.3
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Problem

The **Release** workflow started failing today (2026-06-27) at the changesets step:

```
🦋 error FetchError: Invalid response body while trying to fetch
   https://api.github.com/graphql: Premature close
   code: 'ERR_STREAM_PREMATURE_CLOSE'
```

No change to our code or dependencies — the last green release (Jun 24) and today's failures run the identical path.

## Root cause (verified, not guessed)

1. The release job runs on `ubuntu-latest` (**GitHub-hosted**; the other workflows use Blacksmith and are unaffected).
2. The runner image refreshed `ubuntu24/20260615` → `20260622`, which (per GitHub's own release notes) bumped cached **Node 22.x: `22.22.3` → `22.23.0`** (and 24.x: 24.16.0 → 24.17.0).
3. That Node release carries an `http.Agent` keep-alive socket-reuse regression — [nodejs/node#63989](https://github.com/nodejs/node/issues/63989) — which makes **`node-fetch@2`** throw `ERR_STREAM_PREMATURE_CLOSE` on reused pooled sockets to chunked/gzip HTTPS endpoints.
4. `@changesets/get-github-info` uses `node-fetch@2` for the GitHub GraphQL changelog enrichment → fails.
5. Confirmed by the version diff in the logs: last green release ran **Node 22.22.3**; the 4 failures ran **22.23.0**.

## Fix

Pin `node-version: 22.22.3` (the last-good patch) in `release.yml` — the upstream-recommended "pin Node" workaround. Reversible once a fixed 22.23.x ships and the runner image picks it up.

Only `release.yml` needs it: CI/e2e/publish run on Blacksmith runners, which don't hit this regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)