### PR TITLE
fix(demo): redeploy on demo changes + strip caller repo on groupless calls

### DIFF
--- a/demo/server/oauth/proxy-agent.ts
+++ b/demo/server/oauth/proxy-agent.ts
@@ -86,9 +86,13 @@ export async function callGroupService(
 
   // The group is identified by `repo`: querystring for queries, body for
   // procedures (matches the group service's verifier, which reads repo before
-  // the body is parsed for queries). Omitted for service-level methods.
+  // the body is parsed for queries). `repo` is always owned by this function:
+  // strip any caller-supplied value, then set it from groupDid. For a groupless
+  // (service-level) method that leaves no repo at all, so the caller cannot
+  // smuggle a target group back into a JWT-`iss`-only request.
   const params = new URLSearchParams(opts.params ?? {})
-  if (groupDid) params.set('repo', groupDid) // forced last — wins over caller params
+  params.delete('repo')
+  if (groupDid) params.set('repo', groupDid)
   const query = params.toString()
   const url = `${GROUP_SERVICE_URL.replace(/\/$/, '')}/xrpc/${nsid}${query ? `?${query}` : ''}`
 
@@ -98,8 +102,10 @@ export async function callGroupService(
     headers['Content-Type'] = 'application/json'
     // Include repo in the body too so procedure handlers that read input.body.repo
     // resolve the same group (the confused-deputy guard requires body == querystring).
-    // repo is forced last so a caller-supplied repo cannot override groupDid.
-    requestBody = JSON.stringify(groupDid ? { ...(opts.body ?? {}), repo: groupDid } : (opts.body ?? {}))
+    const body: Record<string, unknown> = { ...(opts.body ?? {}) }
+    delete body.repo
+    if (groupDid) body.repo = groupDid
+    requestBody = JSON.stringify(body)
   }
 
   return fetchUpstream(url, { method: opts.method, headers, body: requestBody })

--- a/railway-demo.toml
+++ b/railway-demo.toml
@@ -20,6 +20,11 @@
 [build]
 builder = "dockerfile"
 dockerfilePath = "demo/Dockerfile"
+# Only redeploy when something the demo image actually builds from changes.
+# The Dockerfile copies only demo/* (repo root is the build context), so a
+# change elsewhere in the repo — e.g. the group service under src/ — must not
+# rebuild the demo. Include this config file so deploy-config edits redeploy.
+watchPatterns = ["demo/**", "railway-demo.toml"]
 
 [deploy]
 healthcheckPath = "/api/health"


### PR DESCRIPTION
## Why

Two demo fixes, the first explaining why https://demo.dev.groups.certified.app didn't show the "my groups" picker after the v0.5.0 dev upgrade.

### 1. Demo didn't redeploy on demo changes (`railway-demo.toml`)

The "my groups" picker (PR #62) merged to `main` and rode into `dev` with the v0.5.0 upgrade — the code **is** in `dev` and in the `v0.5.0` tag. But the live demo kept serving the old build because the **demo Railway service never redeployed**.

The demo service shares the repo with the group service but its config had **no `watchPatterns`**, so a push touching `demo/` didn't trigger a demo redeploy.

Fix: scope deploys to what the demo image actually builds from. The Dockerfile copies only `demo/*` (repo root is the build context), so:

```toml
watchPatterns = ["demo/**", "railway-demo.toml"]
```

Now demo changes redeploy the demo (and unrelated `src/` changes no longer do).

### 2. Strip caller-supplied `repo` on groupless calls (`proxy-agent.ts`)

A CodeRabbit security finding on PR #62 that **landed after that PR was already merged**, so it never made it into `main`. Cherry-picked here.

On a groupless (service-level) call, `callGroupService` still forwarded any `repo` from `opts.params` / `opts.body`, letting a caller smuggle a target group into a request meant to be scoped by the JWT `iss` alone. `repo` is now always owned by the function: strip any caller value, then set from `groupDid` (or leave absent). The service-auth verifier already ignores `repo`, so this is defense-in-depth.

## Testing

- demo: `tsc --noEmit` clean (client + server), `pnpm test` 16 passed, prettier clean.
- `railway-demo.toml` validated as well-formed TOML.
- No changeset: demo-only, nothing for service consumers to adapt to.

## Note

⚠️ Deploying this fix is itself the test that the `watchPatterns` change works: once merged into `dev`, the demo should redeploy and finally show the picker. **The Railway demo service must have config-as-code path = `railway-demo.toml`** (per the file header) for `watchPatterns` to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request routing so destination settings can’t be accidentally overridden by incoming request data.
  * Ensured service calls only include the correct routing information when needed.

* **Chores**
  * Limited demo rebuilds to demo-related files and the demo config, reducing unnecessary redeploys from unrelated changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->