### PR TITLE
feat: public, interoperable record authorship via sidecar records

### DIFF
--- a/.changeset/public-record-authorship.md
+++ b/.changeset/public-record-authorship.md
@@ -1,0 +1,16 @@
+---
+'group-service': minor
+---
+
+Publish record authorship publicly and interoperably via `app.certified.group.authorship` sidecar records.
+
+Every record created through the service now gets an attribution sidecar written into the group's own repo — in the **same `applyWrites` commit** as the record itself — containing the subject at-uri, the author's DID, an optional `via` API-key ref, and a timestamp. Attribution is therefore readable by any atproto client via plain `com.atproto.repo.getRecord` (deterministic rkey `<collection>:<rkey>`), flows over the firehose, survives CAR exports and migrations, and no longer depends on this service's internal database: `group_record_authors` is demoted to a derived RBAC index, and `group.import` rehydrates it from the repo's sidecars.
+
+Also included:
+
+- The `app.certified.group.authorship` collection is service-managed — direct `createRecord`/`putRecord`/`deleteRecord` calls against it are rejected with `InvalidRequest` (they could forge or erase attribution).
+- `deleteRecord` cleans up the subject's sidecar (best-effort, idempotent).
+- New operator endpoint `app.certified.group.admin.backfillAuthorship` (HTTP Basic, idempotent) publishes sidecars for records created before this feature, preserving original author and creation time.
+- `validate: true` on create paths degrades to the PDS default (validate known lexicons), since the commit-wide flag would reject the sidecar's lexicon; `validate: false` passes through unchanged.
+
+See `docs/design/record-authorship.md` for the full design.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ contributor-facing.
 - **Blob uploads** read the raw request stream into memory (not streamed to PDS). Route registration order matters: `registerRawRoutes` (uploadBlob) is mounted before `express.json()`, `registerJsonRoutes` after. New raw-stream routes go in `registerRawRoutes`.
 - **Owner is created only** at group bootstrap — `group.register` and `group.import` both seed it via the shared `finalizeGroup` (`memberIndex.add(..., 'owner', ...)`) — and is immutable through the member-facing API: `role.set` rejects both promoting to owner and modifying an existing owner, `member.remove` rejects removing an owner, and `member.add` caps at admin. The **one** exception is the operator-only `app.certified.group.admin.setOwner` (HTTP Basic auth, `CGS_ADMIN_PASSWORD`), which reassigns ownership in-process via `MemberIndex.transferOwner` (demotes the old owner to admin; promotes the new owner in place, or adds them as a new owner member if they aren't a member yet — the break-glass case where the incumbent owner is unavailable). A member-initiated, accept-to-confirm ownership transfer is still not implemented.
 - **Record authorship is immutable**: `onConflict(...).doNothing()` preserves original author on putRecord. Used to gate cross-author mutations — only admins can `putAnyRecord` or `deleteAnyRecord`; members can only edit/delete records they authored.
+- **Authorship sidecars are the public source of truth**: every create also writes an `app.certified.group.authorship` record into the group's repo, in the **same `applyWrites` commit** as the subject record (deterministic rkey `<collection>:<rkey>`, sha256 fallback past 512 chars — helpers in `src/authorship.ts`). The collection is service-managed: `createRecord`/`putRecord`/`deleteRecord` reject it up front. `group_record_authors` is a derived index — `group.import` rehydrates it from repo sidecars, and `admin.backfillAuthorship` publishes pre-sidecar rows into the repo. Caveat: `validate: true` on create paths degrades to the PDS default because the commit-wide flag would reject the sidecar's (PDS-unknown) lexicon. See `docs/design/record-authorship.md`.
 - **Profile edits** (`app.bsky.actor.profile` + rkey `self`) use a special operation `putRecord:profile` requiring admin, regardless of authorship.
 - **`datetime('now')` is step-stable, not transaction-stable**: each `prepare().run()` maps to a separate `sqlite3_step()`, so two INSERTs in the same transaction can produce different timestamps. When the same timestamp must appear in multiple tables, read it back from the first INSERT and reuse it.
 
@@ -80,14 +81,14 @@ feature), add tests for other code to compensate.
 
 ## Coverage Summary
 
-Baseline as of this document (473 tests across 37 files):
+Baseline as of this document (512 tests across 41 files):
 
 | Metric     | Coverage | Threshold |
 | ---------- | -------- | --------- |
-| Statements | 94.83%   | 94        |
-| Branches   | 91.73%   | 91        |
-| Functions  | 93.06%   | 93        |
-| Lines      | 94.83%   | 94        |
+| Statements | 95.31%   | 95        |
+| Branches   | 91.95%   | 91        |
+| Functions  | 93.44%   | 93        |
+| Lines      | 95.31%   | 95        |
 
 ### Known gaps (highest impact first)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -223,13 +223,48 @@ These endpoints proxy requests to the group's backing PDS after authentication a
 
 Each record operation accepts both the standard AT Protocol NSID and a custom alias. For example, `com.atproto.repo.createRecord` and `app.certified.group.repo.createRecord` are interchangeable. The custom NSIDs are useful when the client's PDS needs an explicit lexicon to route via `atproto-proxy`.
 
+### Record authorship (public attribution)
+
+Every record created through the service is publicly attributed to the member
+who wrote it: an `app.certified.group.authorship` sidecar record is written
+into the group's repo in the **same commit** as the record itself, containing
+the subject's at-uri, the author's DID, an optional `via` (API-key ref, for
+daemon-written records), and a timestamp.
+
+Attribution is read straight from the group's repo — no group-service API is
+involved, so any atproto client, AppView, or firehose consumer can use it:
+
+```bash
+# Who authored at://<group>/app.bsky.feed.post/3abc123 ?
+curl "https://pds.example.com/xrpc/com.atproto.repo.getRecord?repo=did:plc:group123&collection=app.certified.group.authorship&rkey=app.bsky.feed.post:3abc123"
+```
+
+The sidecar rkey is deterministic: `<subject-collection>:<subject-rkey>` (or
+the sha256 hex of that string in the rare case it exceeds 512 characters).
+Attribution records the original creator and is never rewritten by later
+edits. Records created before this feature have no sidecar until the operator
+runs [`admin.backfillAuthorship`](#post-xrpcappcertifiedgroupadminbackfillauthorship).
+
+The `app.certified.group.authorship` collection is **service-managed**:
+`createRecord`, `putRecord`, and `deleteRecord` reject it with `400
+InvalidRequest` (a direct write could forge attribution; a direct delete could
+erase it). Sidecars are cleaned up automatically when their subject record is
+deleted.
+
+See [docs/design/record-authorship.md](design/record-authorship.md) for the full design.
+
 ### `POST /xrpc/com.atproto.repo.createRecord`
 
 Alias: `POST /xrpc/app.certified.group.repo.createRecord`
 
-Create a new record in the group's repository.
+Create a new record in the group's repository, together with its
+[authorship sidecar](#record-authorship-public-attribution) (same commit).
 
 **Required role:** member
+
+> `validate: false` is passed through to the PDS; `validate: true` degrades to
+> the default (validate known lexicons), because the commit-wide flag would
+> reject the authorship sidecar's lexicon, which the PDS does not know.
 
 The target group is named by the `repo` body field (a handle or DID), with JWT `aud` = service DID. The legacy `aud` = group DID form (no `repo`) still works but is deprecated; see [Targeting a group](#targeting-a-group).
 
@@ -259,11 +294,12 @@ The target group is named by the `repo` body field (a handle or DID), with JWT `
 
 **Errors:**
 
-| Code | Name                   | Description                                            |
-| ---- | ---------------------- | ------------------------------------------------------ |
-| 401  | AuthenticationRequired | Missing or invalid JWT                                 |
-| 401  | Unknown group          | `repo` names no registered group (or fails to resolve) |
-| 403  | Forbidden              | Caller lacks member role                               |
+| Code | Name                   | Description                                                          |
+| ---- | ---------------------- | -------------------------------------------------------------------- |
+| 400  | InvalidRequest         | `collection` is the service-managed `app.certified.group.authorship` |
+| 401  | AuthenticationRequired | Missing or invalid JWT                                               |
+| 401  | Unknown group          | `repo` names no registered group (or fails to resolve)               |
+| 403  | Forbidden              | Caller lacks member role                                             |
 
 **Example:**
 
@@ -288,7 +324,9 @@ curl -X POST https://group-service.example.com/xrpc/com.atproto.repo.createRecor
 
 Alias: `POST /xrpc/app.certified.group.repo.putRecord`
 
-Update an existing record or create one at a specific key.
+Update an existing record or create one at a specific key. Creating a new
+record also writes its [authorship sidecar](#record-authorship-public-attribution)
+(same commit); updating an existing record leaves its attribution untouched.
 
 **Required role:** Depends on context:
 
@@ -327,11 +365,12 @@ The target group is named by the `repo` body field (a handle or DID), with JWT `
 
 **Errors:**
 
-| Code | Name                   | Description                                            |
-| ---- | ---------------------- | ------------------------------------------------------ |
-| 401  | AuthenticationRequired | Missing or invalid JWT                                 |
-| 401  | Unknown group          | `repo` names no registered group (or fails to resolve) |
-| 403  | Forbidden              | Caller lacks required role for this operation          |
+| Code | Name                   | Description                                                          |
+| ---- | ---------------------- | -------------------------------------------------------------------- |
+| 400  | InvalidRequest         | `collection` is the service-managed `app.certified.group.authorship` |
+| 401  | AuthenticationRequired | Missing or invalid JWT                                               |
+| 401  | Unknown group          | `repo` names no registered group (or fails to resolve)               |
+| 403  | Forbidden              | Caller lacks required role for this operation                        |
 
 **Example:**
 
@@ -357,7 +396,9 @@ curl -X POST https://group-service.example.com/xrpc/com.atproto.repo.putRecord \
 
 Alias: `POST /xrpc/app.certified.group.repo.deleteRecord`
 
-Delete a record from the group's repository.
+Delete a record from the group's repository. Its
+[authorship sidecar](#record-authorship-public-attribution), if any, is
+deleted as well.
 
 **Required role:**
 
@@ -386,11 +427,12 @@ The target group is named by the `repo` body field (a handle or DID), with JWT `
 
 **Errors:**
 
-| Code | Name                   | Description                                            |
-| ---- | ---------------------- | ------------------------------------------------------ |
-| 401  | AuthenticationRequired | Missing or invalid JWT                                 |
-| 401  | Unknown group          | `repo` names no registered group (or fails to resolve) |
-| 403  | Forbidden              | Caller lacks required role                             |
+| Code | Name                   | Description                                                          |
+| ---- | ---------------------- | -------------------------------------------------------------------- |
+| 400  | InvalidRequest         | `collection` is the service-managed `app.certified.group.authorship` |
+| 401  | AuthenticationRequired | Missing or invalid JWT                                               |
+| 401  | Unknown group          | `repo` names no registered group (or fails to resolve)               |
+| 403  | Forbidden              | Caller lacks required role                                           |
 
 **Example:**
 
@@ -866,21 +908,22 @@ Entries are ordered newest first (`id DESC`). The `detail` field is a JSON objec
 
 Every audited operation produces one of the following `action` strings. Denied operations use the same action value with `"result": "denied"` and an additional `reason` field in `detail`.
 
-| Action              | Trigger                                                           | `detail` fields                                     |
-| ------------------- | ----------------------------------------------------------------- | --------------------------------------------------- |
-| `group.register`    | Group created via `app.certified.group.register`                  | `{ handle }`                                        |
-| `group.import`      | Existing account imported via `app.certified.group.import`        | `{ handle }`                                        |
-| `member.add`        | Member added via `member.add`                                     | `{ memberDid, role }`                               |
-| `member.remove`     | Member removed via `member.remove`                                | `{ memberDid }`                                     |
-| `role.set`          | Role changed via `role.set`                                       | `{ memberDid, previousRole, newRole }`              |
-| `admin.setOwner`    | Owner reassigned via the admin `setOwner` endpoint                | `{ newOwner, previousOwner, addedAsMember, noop? }` |
-| `createRecord`      | Record created (via `createRecord` or `putRecord` for a new rkey) | `{ collection, rkey }`                              |
-| `putOwnRecord`      | Caller updated a record they authored                             | `{ collection, rkey }`                              |
-| `putAnyRecord`      | Caller updated another member's record                            | `{ collection, rkey }`                              |
-| `putRecord:profile` | Group profile updated (`app.bsky.actor.profile` rkey `self`)      | `{ collection, rkey }`                              |
-| `deleteOwnRecord`   | Caller deleted a record they authored                             | `{ collection, rkey }`                              |
-| `deleteAnyRecord`   | Caller deleted another member's record                            | `{ collection, rkey }`                              |
-| `uploadBlob`        | Blob uploaded via `uploadBlob`                                    | _(none)_                                            |
+| Action                     | Trigger                                                           | `detail` fields                                     |
+| -------------------------- | ----------------------------------------------------------------- | --------------------------------------------------- |
+| `group.register`           | Group created via `app.certified.group.register`                  | `{ handle }`                                        |
+| `group.import`             | Existing account imported via `app.certified.group.import`        | `{ handle }`                                        |
+| `member.add`               | Member added via `member.add`                                     | `{ memberDid, role }`                               |
+| `member.remove`            | Member removed via `member.remove`                                | `{ memberDid }`                                     |
+| `role.set`                 | Role changed via `role.set`                                       | `{ memberDid, previousRole, newRole }`              |
+| `admin.setOwner`           | Owner reassigned via the admin `setOwner` endpoint                | `{ newOwner, previousOwner, addedAsMember, noop? }` |
+| `admin.backfillAuthorship` | Authorship sidecars backfilled via the admin endpoint             | `{ created, alreadyPresent }`                       |
+| `createRecord`             | Record created (via `createRecord` or `putRecord` for a new rkey) | `{ collection, rkey }`                              |
+| `putOwnRecord`             | Caller updated a record they authored                             | `{ collection, rkey }`                              |
+| `putAnyRecord`             | Caller updated another member's record                            | `{ collection, rkey }`                              |
+| `putRecord:profile`        | Group profile updated (`app.bsky.actor.profile` rkey `self`)      | `{ collection, rkey }`                              |
+| `deleteOwnRecord`          | Caller deleted a record they authored                             | `{ collection, rkey }`                              |
+| `deleteAnyRecord`          | Caller deleted another member's record                            | `{ collection, rkey }`                              |
+| `uploadBlob`               | Blob uploaded via `uploadBlob`                                    | _(none)_                                            |
 
 **Denied entries** include the same `detail` fields as permitted entries, plus a `reason` string explaining why the operation was denied:
 
@@ -1004,3 +1047,55 @@ curl -X POST https://group-service.example.com/xrpc/app.certified.group.admin.se
 > Because the change is applied in-process (through the same database connection
 > the read paths use), it takes effect immediately — no service restart is
 > needed.
+
+### `POST /xrpc/app.certified.group.admin.backfillAuthorship`
+
+Publish [authorship sidecars](#record-authorship-public-attribution) for
+records created before authorship sidecars existed. For every internally
+tracked record author whose sidecar is missing from the group's repo, an
+`app.certified.group.authorship` record is written (batched, 200 writes per
+commit), preserving the original author DID and creation timestamp.
+
+The operation is **idempotent**: sidecars already present in the repo are
+skipped, so re-running is safe. Backfilled sidecars have no `via` field (the
+API-key ref was not tracked historically).
+
+**Authentication:** HTTP Basic (`admin` / `CGS_ADMIN_PASSWORD`).
+
+**Request body:**
+
+| Field  | Type   | Description                  |
+| ------ | ------ | ---------------------------- |
+| `repo` | string | Target group (handle or DID) |
+
+**Response (200):**
+
+```json
+{
+  "groupDid": "did:plc:group123",
+  "created": 42,
+  "alreadyPresent": 7,
+  "total": 49
+}
+```
+
+- `created` — sidecar records written by this call.
+- `alreadyPresent` — sidecar records that already existed in the repo.
+- `total` — internally tracked authorship rows considered.
+
+**Errors:**
+
+| Code | Name                   | Description                                                                              |
+| ---- | ---------------------- | ---------------------------------------------------------------------------------------- |
+| 401  | AuthenticationRequired | Missing/invalid Basic credentials, or admin endpoints disabled (no `CGS_ADMIN_PASSWORD`) |
+| 404  | UnknownGroup           | `repo` does not resolve to a managed group                                               |
+| 502  | UpstreamFailure        | The group's PDS rejected the listing or one of the write batches                         |
+
+**Example:**
+
+```bash
+curl -X POST https://group-service.example.com/xrpc/app.certified.group.admin.backfillAuthorship \
+  -u "admin:$CGS_ADMIN_PASSWORD" \
+  -H "Content-Type: application/json" \
+  -d '{"repo":"did:plc:group123"}'
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,6 +129,7 @@ Roles are compared numerically. A higher level grants all permissions of lower l
 - **Self-removal always succeeds**: Any member can remove themselves regardless of role
 - **Owner role is immutable**: `role.set` rejects both promoting a member to owner (`CannotPromoteToOwner`) and changing an existing owner's role (`CannotModifyOwner`); `member.remove` rejects removing an owner (`CannotRemoveOwner`). Each group has exactly one owner (the registrant). Ownership transfer is a separate operation that is not yet implemented.
 - **Author-based record ownership**: `putRecord` and `deleteRecord` check the `group_record_authors` table to determine if the caller authored the record, then select the appropriate operation (`putOwnRecord` / `putAnyRecord` vs `putRecord:profile`, `deleteOwnRecord` vs `deleteAnyRecord`). Members can only edit or delete their own records; editing or deleting another member's record requires admin.
+- **Public authorship sidecars**: every record created through CGS also gets an `app.certified.group.authorship` record written into the group's repo (in the same `applyWrites` commit for creates), publishing who authored it — publicly and interoperably, independent of this service's internal state. The sidecar collection is service-managed: direct writes or deletes to it are rejected (`InvalidRequest`), since they could forge or erase attribution. See [docs/design/record-authorship.md](design/record-authorship.md).
 
 ### RBAC enforcement
 
@@ -199,6 +200,13 @@ Composite index on `(added_at, member_did)` for efficient paginated listing.
 | `created_at` | TEXT      | ISO timestamp                    |
 
 Indexed on `author_did` for authorship lookups.
+
+This table is a **derived index** for fast RBAC own-vs-any checks. The source
+of truth for attribution is the `app.certified.group.authorship` sidecar
+records in the group's own repo: `group.import` rehydrates this table from
+them, and `admin.backfillAuthorship` publishes rows that predate the sidecars
+back into the repo. See
+[docs/design/record-authorship.md](design/record-authorship.md).
 
 #### `group_audit_log`
 

--- a/docs/design/record-authorship.md
+++ b/docs/design/record-authorship.md
@@ -1,0 +1,173 @@
+# Public, interoperable record authorship
+
+## Problem
+
+In atproto, a repository has exactly one author: the repo's DID. Every record
+written through CGS is committed and signed by the _group's_ identity, so
+which member actually created a record is invisible to the network. Consumers
+of a group's data (e.g. a frontend rendering a group's page) cannot show
+"created by @member" without asking the group service.
+
+CGS has always known the answer — every `createRecord`/`putRecord` writes a row
+to the per-group `group_record_authors` table — but that table was:
+
+- **Private.** It fed only the RBAC own-vs-any checks; no endpoint exposed it.
+  (The audit log records the same information but is admin-only, mirroring the
+  situation apps like Ma Earth have today: attribution exists but only in an
+  internal, privileged log.)
+- **Not interoperable.** An internal SQLite table does not appear on the
+  firehose, is not part of CAR exports, cannot be indexed by an AppView, and
+  is lost if the group migrates to a different group service. Relying on it as
+  the source of truth couples authorship to one CGS deployment.
+
+## Options considered
+
+1. **Public query endpoint over the internal table** (e.g.
+   `getRecordAuthor?uri=…`). Cheap, but attribution remains exactly as durable
+   as one service's SQLite files, and every consumer must integrate with CGS
+   specifically. Rejected as the primary mechanism.
+2. **Stamp an author field into the record payload.** Travels with the record,
+   but silently mutates user data, breaks closed lexicons under validation, and
+   can be stripped or forged by any later edit. Rejected.
+3. **Authorship sidecar records in the group's repo.** Chosen — see below.
+
+## Design: `app.certified.group.authorship` sidecars
+
+For every record created through CGS, the service writes a companion record
+into the group's own repo:
+
+```jsonc
+// at://<group>/app.certified.group.authorship/<collection>:<rkey>
+{
+  "$type": "app.certified.group.authorship",
+  "subject": "at://did:plc:group/app.bsky.feed.post/3abc",
+  "author": "did:plc:member1",
+  "via": "cgsk_…", // optional: API-key ref for daemon-written records
+  "createdAt": "2026-07-07T12:00:00.000Z",
+}
+```
+
+Because the sidecar lives in the signed repo, attribution is now:
+
+- **Public** — any client can read it with plain `com.atproto.repo.getRecord`
+  / `listRecords`; no CGS API involved.
+- **Interoperable** — it flows over the firehose, survives in CAR exports,
+  can be indexed by any AppView, and travels with the repo across PDS or
+  group-service migrations. Another group service adopting the lexicon
+  inherits the full attribution history.
+- **Durable** — the internal `group_record_authors` table is demoted from
+  source of truth to a **derived index** for fast RBAC lookups. `group.import`
+  rebuilds it from the repo's sidecars (see Rehydration).
+
+### Deterministic rkey
+
+The sidecar's rkey is `<subject-collection>:<subject-rkey>` (e.g.
+`app.bsky.feed.post:3abc`), so attribution for a known record is a direct
+`getRecord` away — no scanning. Both NSIDs and rkeys draw from the rkey-legal
+charset (`[A-Za-z0-9._:~-]`), so the composite is always valid; if it would
+exceed the 512-char rkey cap, the sha256 hex of the composite is used instead
+(64 chars, deterministic, same lookup procedure).
+
+### Atomicity
+
+`createRecord` (and `putRecord` creating a genuinely new record) writes the
+subject record and its sidecar in a **single `com.atproto.repo.applyWrites`
+commit**: there is no window in which a record exists unattributed, both land
+on the firehose together, and it costs one PDS round-trip instead of two.
+
+Consequences:
+
+- CGS picks the rkey client-side (a TID via `@atproto/common-web`) when the
+  caller does not supply one, because the sidecar embeds the subject's at-uri
+  and must be built before the commit.
+- **`validate` caveat:** `applyWrites`' `validate` flag is commit-wide, and
+  the PDS does not know the `app.certified.group.authorship` lexicon, so
+  `validate: true` would fail the entire commit. CGS passes `false` through
+  and degrades `true` to the default (validate known lexicons — the caller's
+  record still receives a `validationStatus`).
+
+### Non-atomic edges (best-effort)
+
+Two paths cannot be atomic and are deliberately best-effort — a failure is
+logged, never surfaced, and repairable via the backfill:
+
+- **Delete cleanup.** `deleteRecord` deletes the subject, then the sidecar in
+  a separate call. `applyWrites` cannot batch them because a delete of a
+  missing key fails the whole commit, and legacy records have no sidecar;
+  plain `deleteRecord` is idempotent on the PDS, so this works for both. Worst
+  case is an **orphaned sidecar**, which consumers must ignore once its
+  subject no longer resolves.
+- **Legacy-record edits.** `putRecord` on a record that exists on the PDS but
+  has no tracked author (created before this feature, or imported) keeps the
+  existing semantics — the edit attributes the record to the editor — and
+  writes the sidecar after the update succeeds. (A brand-new record is
+  detected with a `getRecord` probe and takes the atomic path.)
+
+### The collection is service-managed
+
+Direct `createRecord`/`putRecord`/`deleteRecord` calls targeting
+`app.certified.group.authorship` are rejected with `InvalidRequest`: a member
+who could write the collection directly could forge attribution; one who could
+delete from it could erase attribution while the subject record lives on.
+Sidecars are written and removed exclusively by CGS alongside their subjects.
+
+### Immutability
+
+Attribution records the **original creator** and is never rewritten: an edit
+(even `putAnyRecord` by an admin) leaves the sidecar untouched, matching the
+existing `onConflict(...).doNothing()` semantics of the internal table. Edit
+history remains the audit log's job.
+
+## Backfill: `app.certified.group.admin.backfillAuthorship`
+
+Records created before this feature are attributed only in the internal table.
+The operator-only endpoint (HTTP Basic, like `admin.setOwner`) publishes that
+attribution into the repo:
+
+1. Enumerate existing sidecars (`listRecords`, paginated) so the operation is
+   idempotent.
+2. For every `group_record_authors` row without a sidecar, write one —
+   preserving the original author DID and creation timestamp — batched via
+   `applyWrites` in chunks of 200 (the PDS per-commit cap).
+
+Backfilled sidecars have no `via` (the key ref was not tracked historically).
+The call is audit-logged as actor `admin`.
+
+## Rehydration on `group.import`
+
+After a successful import, CGS scans the repo for
+`app.certified.group.authorship` records and seeds `group_record_authors` from
+them (original author and creation time preserved; malformed values skipped).
+This is what makes the internal table genuinely derived: a group migrating
+from another CGS instance arrives with its attribution — and therefore its
+own-record edit/delete permissions — intact. The pass is best-effort and never
+fails the import.
+
+## Trust model and limitations
+
+- The sidecar is signed by the **group's** repo key: it is the group service
+  attesting "member X wrote this", the same trust level as the audit log — not
+  cryptographic proof by the member. Author-signed attribution would require
+  members to sign record hashes with their own keys and is out of scope.
+- **Privacy:** attribution makes member DIDs publicly linkable to content,
+  which is more than the members-only `member.list` exposes today. Groups for
+  whom this is a problem should not adopt the backfill; a per-group opt-out
+  for sidecar writes is a possible follow-up if demanded.
+- An external (non-CGS) write directly to the group's PDS bypasses attribution
+  entirely — unchanged from before this feature.
+
+## Consuming attribution (for app developers)
+
+To show "created by" for `at://<group>/<collection>/<rkey>`:
+
+```
+GET <group-pds>/xrpc/com.atproto.repo.getRecord
+    ?repo=<group>
+    &collection=app.certified.group.authorship
+    &rkey=<collection>:<rkey>
+```
+
+Resolve `author` to a handle/profile as usual. If the sidecar is missing, the
+record predates attribution (ask the group's operator to run the backfill) or
+was written outside CGS. Always verify the `subject` record still exists
+before trusting an attribution record.

--- a/lexicons/app/certified/group/admin/backfillAuthorship.json
+++ b/lexicons/app/certified/group/admin/backfillAuthorship.json
@@ -1,0 +1,50 @@
+{
+  "lexicon": 1,
+  "id": "app.certified.group.admin.backfillAuthorship",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Write app.certified.group.authorship sidecar records into the group's repo for every internally-tracked record author that does not yet have one. Operator-only: authenticated with HTTP Basic auth (username \"admin\") against the service CGS_ADMIN_PASSWORD, not group membership. Idempotent — sidecars already present in the repo are skipped.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["repo"],
+          "properties": {
+            "repo": {
+              "type": "string",
+              "format": "at-identifier",
+              "description": "The handle or DID of the group to backfill."
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["groupDid", "created", "alreadyPresent", "total"],
+          "properties": {
+            "groupDid": { "type": "string", "format": "did" },
+            "created": {
+              "type": "integer",
+              "description": "Number of sidecar records written by this call."
+            },
+            "alreadyPresent": {
+              "type": "integer",
+              "description": "Number of sidecar records that already existed in the repo."
+            },
+            "total": {
+              "type": "integer",
+              "description": "Total internally-tracked authorship rows considered."
+            }
+          }
+        }
+      },
+      "errors": [
+        { "name": "Unauthorized" },
+        { "name": "UnknownGroup", "description": "The repo does not resolve to a managed group." }
+      ]
+    }
+  }
+}

--- a/lexicons/app/certified/group/authorship.json
+++ b/lexicons/app/certified/group/authorship.json
@@ -1,0 +1,36 @@
+{
+  "lexicon": 1,
+  "id": "app.certified.group.authorship",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Attribution sidecar written by a group service: records which group member authored a record in the group's repository. Written in the same commit as the subject record, with rkey '<subject-collection>:<subject-rkey>' (or the sha256 hex of that string when it would exceed 512 characters), so attribution for a known record is a direct getRecord away. This collection is service-managed — direct writes through the group service's record endpoints are rejected.",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": ["subject", "author", "createdAt"],
+        "properties": {
+          "subject": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "The record this attribution describes."
+          },
+          "author": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the group member who created the subject record."
+          },
+          "via": {
+            "type": "string",
+            "description": "Reference of the API key that performed the write, when the record was created by a key-authenticated daemon rather than an interactive member session."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "When the subject record was created."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/certified/group/repo/createRecord.json
+++ b/lexicons/app/certified/group/repo/createRecord.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "procedure",
-      "description": "Create a record in the group's repository. Proxied through the user's PDS.",
+      "description": "Create a record in the group's repository, together with an app.certified.group.authorship sidecar attributing it to the caller (written in the same commit). Proxied through the group's PDS.",
       "input": {
         "encoding": "application/json",
         "schema": {
@@ -14,7 +14,16 @@
             "repo": { "type": "string", "format": "at-identifier" },
             "collection": { "type": "string", "format": "nsid" },
             "rkey": { "type": "string" },
-            "record": { "type": "unknown" }
+            "record": { "type": "unknown" },
+            "validate": {
+              "type": "boolean",
+              "description": "'false' skips Lexicon schema validation of record data. 'true' degrades to the default (validate known Lexicons): the record and its authorship sidecar share one commit, and the commit-wide flag would reject the sidecar's Lexicon, which the PDS does not know."
+            },
+            "swapCommit": {
+              "type": "string",
+              "format": "cid",
+              "description": "Compare and swap with the previous commit by CID."
+            }
           }
         }
       },

--- a/lexicons/app/certified/group/repo/putRecord.json
+++ b/lexicons/app/certified/group/repo/putRecord.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "procedure",
-      "description": "Create or update a record in the group's repository. Proxied through the user's PDS.",
+      "description": "Create or update a record in the group's repository. Creating a new record also writes an app.certified.group.authorship sidecar attributing it to the caller (in the same commit); updating an existing record leaves its attribution untouched. Proxied through the group's PDS.",
       "input": {
         "encoding": "application/json",
         "schema": {
@@ -14,7 +14,16 @@
             "repo": { "type": "string", "format": "at-identifier" },
             "collection": { "type": "string", "format": "nsid" },
             "rkey": { "type": "string" },
-            "record": { "type": "unknown" }
+            "record": { "type": "unknown" },
+            "validate": {
+              "type": "boolean",
+              "description": "'false' skips Lexicon schema validation of record data. When the write creates a new record, 'true' degrades to the default (validate known Lexicons) — see app.certified.group.repo.createRecord."
+            },
+            "swapCommit": {
+              "type": "string",
+              "format": "cid",
+              "description": "Compare and swap with the previous commit by CID."
+            }
           }
         }
       },

--- a/src/api/admin/backfillAuthorship.ts
+++ b/src/api/admin/backfillAuthorship.ts
@@ -1,0 +1,110 @@
+import type { Server } from '@atproto/xrpc-server'
+import { XRPCError, AuthRequiredError } from '@atproto/xrpc-server'
+import type { AppContext } from '../../context.js'
+import { registerAdminMethod, jsonResponse, proxyToPds, sqliteToIso } from '../util.js'
+import { AUTHORSHIP_COLLECTION, authorshipRkey, buildAuthorshipRecord } from '../../authorship.js'
+
+/** The PDS caps applyWrites at 200 writes per commit. */
+const APPLY_WRITES_CHUNK = 200
+
+/**
+ * app.certified.group.admin.backfillAuthorship — operator-only, idempotent.
+ *
+ * Records created before authorship sidecars existed are attributed only in
+ * the internal `group_record_authors` table. This endpoint publishes that
+ * attribution into the group's repo: for every tracked row whose sidecar is
+ * missing, it writes an `app.certified.group.authorship` record (batched via
+ * applyWrites), preserving the original author DID and creation timestamp.
+ *
+ * Idempotency: existing sidecars are enumerated first (listRecords) and their
+ * rows skipped, so re-running is safe and cheap.
+ *
+ * Like all admin endpoints this is HTTP Basic-authenticated against
+ * CGS_ADMIN_PASSWORD (see registerAdminMethod) and audit-logged as actor
+ * `admin`.
+ */
+export default function (server: Server, ctx: AppContext) {
+  registerAdminMethod(server, 'app.certified.group.admin.backfillAuthorship', ctx, {
+    handler: async ({ input }) => {
+      const { repo } = input?.body as { repo: string }
+      const groupDid = await resolveGroup(ctx, repo)
+      const groupDb = ctx.groupDbs.get(groupDid)
+
+      // 1. Enumerate sidecars already in the repo, so the backfill is
+      //    idempotent.
+      const existing = new Set<string>()
+      await proxyToPds(ctx.pdsAgents, groupDid, async (agent) => {
+        let cursor: string | undefined
+        do {
+          const res = await agent.com.atproto.repo.listRecords({
+            repo: groupDid,
+            collection: AUTHORSHIP_COLLECTION,
+            limit: 100,
+            cursor,
+          })
+          for (const record of res.data.records) {
+            const rkey = record.uri.split('/').pop()
+            if (rkey !== undefined) existing.add(rkey)
+          }
+          cursor = res.data.cursor
+        } while (cursor !== undefined)
+      })
+
+      // 2. Tracked authorship rows lacking a sidecar. Rows for the sidecar
+      //    collection itself are skipped defensively (they should not exist —
+      //    direct writes to it are rejected).
+      const rows = await groupDb.selectFrom('group_record_authors').selectAll().execute()
+      const missing = rows.flatMap((row) => {
+        const rkey = row.record_uri.split('/').pop()
+        if (rkey === undefined || row.collection === AUTHORSHIP_COLLECTION) return []
+        const sidecarRkey = authorshipRkey(row.collection, rkey)
+        if (existing.has(sidecarRkey)) return []
+        return [{ row, sidecarRkey }]
+      })
+
+      // 3. Write the missing sidecars in applyWrites chunks.
+      for (let i = 0; i < missing.length; i += APPLY_WRITES_CHUNK) {
+        const chunk = missing.slice(i, i + APPLY_WRITES_CHUNK)
+        await proxyToPds(ctx.pdsAgents, groupDid, (agent) =>
+          agent.com.atproto.repo.applyWrites({
+            repo: groupDid,
+            writes: chunk.map(({ row, sidecarRkey }) => ({
+              $type: 'com.atproto.repo.applyWrites#create' as const,
+              collection: AUTHORSHIP_COLLECTION,
+              rkey: sidecarRkey,
+              value: buildAuthorshipRecord({
+                subject: row.record_uri,
+                author: row.author_did,
+                createdAt: sqliteToIso(row.created_at),
+              }),
+            })),
+          }),
+        )
+      }
+
+      await ctx.audit.log(groupDb, 'admin', 'admin.backfillAuthorship', 'permitted', {
+        created: missing.length,
+        alreadyPresent: existing.size,
+      })
+
+      return jsonResponse({
+        groupDid,
+        created: missing.length,
+        alreadyPresent: existing.size,
+        total: rows.length,
+      })
+    },
+  })
+}
+
+/** Resolve the `repo` at-identifier to a known group DID (as admin.setOwner). */
+async function resolveGroup(ctx: AppContext, repo: string): Promise<string> {
+  try {
+    return await ctx.authVerifier.resolveRepoToGroup(repo)
+  } catch (err) {
+    if (err instanceof AuthRequiredError) {
+      throw new XRPCError(404, `Unknown group: ${repo}`, 'UnknownGroup')
+    }
+    throw err
+  }
+}

--- a/src/api/group/import.ts
+++ b/src/api/group/import.ts
@@ -3,8 +3,9 @@ import { AtpAgent } from '@atproto/api'
 import { ensureValidDid } from '@atproto/syntax'
 import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
 import type { AppContext } from '../../context.js'
-import { registerServiceAuthMethod, jsonResponse } from '../util.js'
+import { registerServiceAuthMethod, jsonResponse, isoToSqlite } from '../util.js'
 import { finalizeGroup } from './finalize.js'
+import { AUTHORSHIP_COLLECTION } from '../../authorship.js'
 
 /**
  * Require the PDS endpoint resolved from an imported account's DID document to
@@ -134,7 +135,71 @@ export default function (server: Server, ctx: AppContext) {
         handle,
       })
 
+      // Rehydrate the authorship index from any app.certified.group.authorship
+      // sidecar records already present in the repo (e.g. a group migrating
+      // from another CGS instance). The repo is the source of truth for
+      // attribution; group_record_authors is a derived index. Best-effort: a
+      // failure leaves records unattributed (same as pre-sidecar imports) and
+      // must not fail the import.
+      await rehydrateAuthorship(ctx, agent, groupDid)
+
       return jsonResponse({ groupDid, handle })
     },
   })
+}
+
+/**
+ * Scan the imported repo for authorship sidecars and seed the internal
+ * `group_record_authors` index from them, preserving original author and
+ * creation time. Malformed sidecar values are skipped; any failure is logged
+ * and swallowed (the import itself has already succeeded).
+ */
+async function rehydrateAuthorship(
+  ctx: AppContext,
+  agent: AtpAgent,
+  groupDid: string,
+): Promise<void> {
+  try {
+    const groupDb = ctx.groupDbs.get(groupDid)
+    let cursor: string | undefined
+    let rehydrated = 0
+    do {
+      const res = await agent.com.atproto.repo.listRecords({
+        repo: groupDid,
+        collection: AUTHORSHIP_COLLECTION,
+        limit: 100,
+        cursor,
+      })
+      for (const record of res.data.records) {
+        const value = record.value as { subject?: unknown; author?: unknown; createdAt?: unknown }
+        if (typeof value.subject !== 'string' || typeof value.author !== 'string') continue
+        // at://did/collection/rkey → segments [at:, '', did, collection, rkey]
+        const segments = value.subject.split('/')
+        const collection = segments[3]
+        if (segments.length !== 5 || !collection) continue
+        await groupDb
+          .insertInto('group_record_authors')
+          .values({
+            record_uri: value.subject,
+            author_did: value.author,
+            collection,
+            ...(typeof value.createdAt === 'string' && !Number.isNaN(Date.parse(value.createdAt))
+              ? { created_at: isoToSqlite(value.createdAt) }
+              : {}),
+          })
+          .onConflict((oc) => oc.column('record_uri').doNothing())
+          .execute()
+        rehydrated++
+      }
+      cursor = res.data.cursor
+    } while (cursor !== undefined)
+    if (rehydrated > 0) {
+      ctx.logger.info({ groupDid, rehydrated }, 'Rehydrated record authorship from repo sidecars')
+    }
+  } catch (err) {
+    ctx.logger.warn(
+      { err, groupDid },
+      'Could not rehydrate authorship index from repo sidecars; continuing without',
+    )
+  }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -18,6 +18,7 @@ import keysCreate from './keys/create.js'
 import keysList from './keys/list.js'
 import keysDelete from './keys/delete.js'
 import adminSetOwner from './admin/setOwner.js'
+import adminBackfillAuthorship from './admin/backfillAuthorship.js'
 
 export function registerXrpcMethods(server: Server, ctx: AppContext): void {
   createRecord(server, ctx)
@@ -37,4 +38,5 @@ export function registerXrpcMethods(server: Server, ctx: AppContext): void {
   keysList(server, ctx)
   keysDelete(server, ctx)
   adminSetOwner(server, ctx)
+  adminBackfillAuthorship(server, ctx)
 }

--- a/src/api/repo/createRecord.ts
+++ b/src/api/repo/createRecord.ts
@@ -1,4 +1,6 @@
 import type { Server } from '@atproto/xrpc-server'
+import { UpstreamFailureError } from '@atproto/xrpc-server'
+import { TID } from '@atproto/common-web'
 import type { AppContext } from '../../context.js'
 import {
   registerAuthedMethod,
@@ -9,6 +11,12 @@ import {
   type AuthedMethodConfig,
 } from '../util.js'
 import type { Operation } from '../../rbac/permissions.js'
+import {
+  AUTHORSHIP_COLLECTION,
+  authorshipRkey,
+  buildAuthorshipRecord,
+  assertNotAuthorshipCollection,
+} from '../../authorship.js'
 
 export default function (server: Server, ctx: AppContext) {
   const config: AuthedMethodConfig = {
@@ -19,7 +27,13 @@ export default function (server: Server, ctx: AppContext) {
         collection: string
         rkey?: string
         record: { [x: string]: unknown }
+        validate?: boolean
+        swapCommit?: string
       }
+
+      // Authorship sidecars are service-managed; a direct write could forge
+      // attribution.
+      assertNotAuthorshipCollection(input.collection)
 
       // The target group is named by the body `repo` (handle or DID, new path)
       // or, for a legacy caller, carried in the credential from `aud`.
@@ -37,18 +51,64 @@ export default function (server: Server, ctx: AppContext) {
         auth.credentials,
       )
 
-      // Forward to group's PDS via withAgent. Send the resolved group DID as
-      // `repo` — the caller may have supplied a handle, which the PDS won't take.
+      // Pick the rkey up front (normally the PDS mints a TID server-side): the
+      // authorship sidecar embeds the subject's at-uri, so the rkey must be
+      // known before the commit is built.
+      const rkey = input.rkey !== undefined && input.rkey.length > 0 ? input.rkey : TID.nextStr()
+      const subjectUri = `at://${groupDid}/${input.collection}/${rkey}`
+
+      const sidecar = buildAuthorshipRecord({
+        subject: subjectUri,
+        author: callerDid,
+        via: auth.credentials.authKind === 'apiKey' ? auth.credentials.apiKeyRef : undefined,
+      })
+
+      // Write the record and its authorship sidecar in ONE applyWrites commit:
+      // there is no window in which the record exists unattributed, and both
+      // land on the firehose together.
+      //
+      // `validate` note: applyWrites' flag is commit-wide, and the PDS does not
+      // know the app.certified.group.authorship lexicon — `validate: true`
+      // would fail the entire commit. So `false` passes through, while `true`
+      // degrades to the default (validate known lexicons; the caller's record
+      // still gets a validationStatus).
       const response = await proxyToPds(ctx.pdsAgents, groupDid, (agent) =>
-        agent.com.atproto.repo.createRecord({ ...input, repo: groupDid }),
+        agent.com.atproto.repo.applyWrites({
+          repo: groupDid,
+          ...(input.validate === false ? { validate: false } : {}),
+          ...(input.swapCommit !== undefined ? { swapCommit: input.swapCommit } : {}),
+          writes: [
+            {
+              $type: 'com.atproto.repo.applyWrites#create',
+              collection: input.collection,
+              rkey,
+              value: input.record,
+            },
+            {
+              $type: 'com.atproto.repo.applyWrites#create',
+              collection: AUTHORSHIP_COLLECTION,
+              rkey: authorshipRkey(input.collection, rkey),
+              value: sidecar,
+            },
+          ],
+        }),
       )
 
-      // 4. Track authorship + audit log (independent, run in parallel)
+      const subjectResult = response.data.results?.[0]
+      if (
+        subjectResult === undefined ||
+        subjectResult.$type !== 'com.atproto.repo.applyWrites#createResult'
+      ) {
+        throw new UpstreamFailureError('PDS applyWrites returned no result for the created record')
+      }
+
+      // Track authorship index + audit log (independent, run in parallel). The
+      // index mirrors the sidecar for fast RBAC lookups.
       await Promise.all([
         groupDb
           .insertInto('group_record_authors')
           .values({
-            record_uri: response.data.uri,
+            record_uri: subjectResult.uri,
             author_did: callerDid,
             collection: input.collection,
           })
@@ -56,12 +116,19 @@ export default function (server: Server, ctx: AppContext) {
           .execute(),
         ctx.audit.log(groupDb, callerDid, operation, 'permitted', {
           collection: input.collection,
-          rkey: response.data.uri.split('/').pop(),
+          rkey,
         }),
       ])
 
-      // 5. Return PDS response
-      return jsonResponse(response.data)
+      // Shape the response like com.atproto.repo.createRecord would.
+      return jsonResponse({
+        uri: subjectResult.uri,
+        cid: subjectResult.cid,
+        ...(response.data.commit !== undefined ? { commit: response.data.commit } : {}),
+        ...(subjectResult.validationStatus !== undefined
+          ? { validationStatus: subjectResult.validationStatus }
+          : {}),
+      })
     },
   }
   registerAuthedMethod(server, 'app.certified.group.repo.createRecord', ctx, config)

--- a/src/api/repo/deleteRecord.ts
+++ b/src/api/repo/deleteRecord.ts
@@ -9,6 +9,11 @@ import {
   type AuthedMethodConfig,
 } from '../util.js'
 import type { Operation } from '../../rbac/permissions.js'
+import {
+  AUTHORSHIP_COLLECTION,
+  authorshipRkey,
+  assertNotAuthorshipCollection,
+} from '../../authorship.js'
 
 export default function (server: Server, ctx: AppContext) {
   const config: AuthedMethodConfig = {
@@ -19,6 +24,11 @@ export default function (server: Server, ctx: AppContext) {
         collection: string
         rkey: string
       }
+
+      // Authorship sidecars are service-managed; a direct delete could erase
+      // attribution while its subject record lives on. Sidecars are removed
+      // automatically when their subject record is deleted (below).
+      assertNotAuthorshipCollection(input.collection)
 
       const groupDid = await resolveGroupDid(ctx, auth.credentials, input.repo)
 
@@ -38,9 +48,27 @@ export default function (server: Server, ctx: AppContext) {
 
       // Send the resolved group DID as `repo` — the caller may have supplied a
       // handle, which the PDS won't accept.
-      await proxyToPds(ctx.pdsAgents, groupDid, (agent) =>
-        agent.com.atproto.repo.deleteRecord({ ...input, repo: groupDid }),
-      )
+      await proxyToPds(ctx.pdsAgents, groupDid, async (agent) => {
+        await agent.com.atproto.repo.deleteRecord({ ...input, repo: groupDid })
+        // Clean up the authorship sidecar. Separate, best-effort call: the
+        // PDS's deleteRecord is idempotent (no-op success when the record is
+        // absent), so legacy records without sidecars work; and a failure here
+        // must not fail the request — the subject record is already gone.
+        // Worst case is an orphaned sidecar, which consumers must ignore once
+        // its subject no longer resolves.
+        try {
+          await agent.com.atproto.repo.deleteRecord({
+            repo: groupDid,
+            collection: AUTHORSHIP_COLLECTION,
+            rkey: authorshipRkey(input.collection, input.rkey),
+          })
+        } catch (err) {
+          ctx.logger.warn(
+            { err, collection: input.collection, rkey: input.rkey },
+            'Failed to delete authorship sidecar for deleted record',
+          )
+        }
+      })
 
       await Promise.all([
         groupDb.deleteFrom('group_record_authors').where('record_uri', '=', recordUri).execute(),

--- a/src/api/repo/putRecord.ts
+++ b/src/api/repo/putRecord.ts
@@ -1,4 +1,7 @@
 import type { Server } from '@atproto/xrpc-server'
+import { UpstreamFailureError } from '@atproto/xrpc-server'
+import { XRPCError as ClientXRPCError } from '@atproto/xrpc'
+import type { Agent } from '@atproto/api'
 import type { AppContext } from '../../context.js'
 import {
   registerAuthedMethod,
@@ -9,6 +12,39 @@ import {
   type AuthedMethodConfig,
 } from '../util.js'
 import type { Operation } from '../../rbac/permissions.js'
+import {
+  AUTHORSHIP_COLLECTION,
+  authorshipRkey,
+  buildAuthorshipRecord,
+  assertNotAuthorshipCollection,
+} from '../../authorship.js'
+
+/** Output shape shared by putRecord and the applyWrites fallback path. */
+interface PutRecordOutput {
+  uri: string
+  cid: string
+  commit?: unknown
+  validationStatus?: string
+}
+
+/**
+ * Does a record exist in the group repo? Distinguishes the PDS's
+ * `RecordNotFound` from genuine failures, which are rethrown.
+ */
+async function recordExists(
+  agent: Agent,
+  repo: string,
+  collection: string,
+  rkey: string,
+): Promise<boolean> {
+  try {
+    await agent.com.atproto.repo.getRecord({ repo, collection, rkey })
+    return true
+  } catch (err) {
+    if (err instanceof ClientXRPCError && err.error === 'RecordNotFound') return false
+    throw err
+  }
+}
 
 export default function (server: Server, ctx: AppContext) {
   const config: AuthedMethodConfig = {
@@ -19,7 +55,13 @@ export default function (server: Server, ctx: AppContext) {
         collection: string
         rkey: string
         record: { [x: string]: unknown }
+        validate?: boolean
+        swapCommit?: string
       }
+
+      // Authorship sidecars are service-managed; a direct write could forge
+      // attribution.
+      assertNotAuthorshipCollection(input.collection)
 
       const groupDid = await resolveGroupDid(ctx, auth.credentials, input.repo)
 
@@ -27,12 +69,13 @@ export default function (server: Server, ctx: AppContext) {
 
       // Determine operation based on what's being updated
       const isProfileUpdate = input.collection === 'app.bsky.actor.profile' && input.rkey === 'self'
+      const recordUri = `at://${groupDid}/${input.collection}/${input.rkey}`
 
       let operation: Operation
+      let hasAuthorRow = false
       if (isProfileUpdate) {
         operation = 'putRecord:profile'
       } else {
-        const recordUri = `at://${groupDid}/${input.collection}/${input.rkey}`
         const authorRow = await groupDb
           .selectFrom('group_record_authors')
           .select('author_did')
@@ -40,6 +83,7 @@ export default function (server: Server, ctx: AppContext) {
           .executeTakeFirst()
 
         if (authorRow) {
+          hasAuthorRow = true
           operation = authorRow.author_did === callerDid ? 'putOwnRecord' : 'putAnyRecord'
         } else {
           operation = 'createRecord'
@@ -56,11 +100,95 @@ export default function (server: Server, ctx: AppContext) {
         auth.credentials,
       )
 
-      // Forward to group's PDS. Send the resolved group DID as `repo` — the
-      // caller may have supplied a handle, which the PDS won't accept.
-      const response = await proxyToPds(ctx.pdsAgents, groupDid, (agent) =>
-        agent.com.atproto.repo.putRecord({ ...input, repo: groupDid }),
-      )
+      // Forward to the group's PDS. Send the resolved group DID as `repo` —
+      // the caller may have supplied a handle, which the PDS won't accept.
+      //
+      // Three write shapes:
+      // - Profile, or a record with a tracked author: plain putRecord. The
+      //   authorship sidecar (if any) is left untouched — attribution is
+      //   immutable, an edit does not transfer authorship.
+      // - No tracked author + record absent from the PDS: a genuinely new
+      //   record. Write it and its authorship sidecar in one applyWrites
+      //   commit, mirroring createRecord's atomicity.
+      // - No tracked author + record present on the PDS (legacy or imported,
+      //   created before authorship tracking): putRecord as before; the edit
+      //   attributes the record to the caller (existing semantics), so also
+      //   write the sidecar — best-effort, since the subject update has
+      //   already been committed.
+      let output: PutRecordOutput
+      if (isProfileUpdate || hasAuthorRow) {
+        const response = await proxyToPds(ctx.pdsAgents, groupDid, (agent) =>
+          agent.com.atproto.repo.putRecord({ ...input, repo: groupDid }),
+        )
+        output = response.data
+      } else {
+        const sidecar = buildAuthorshipRecord({
+          subject: recordUri,
+          author: callerDid,
+          via: auth.credentials.authKind === 'apiKey' ? auth.credentials.apiKeyRef : undefined,
+        })
+        const sidecarRkey = authorshipRkey(input.collection, input.rkey)
+
+        output = await proxyToPds(ctx.pdsAgents, groupDid, async (agent) => {
+          const exists = await recordExists(agent, groupDid, input.collection, input.rkey)
+          if (!exists) {
+            // See createRecord for the `validate` caveat: the commit-wide flag
+            // would reject the sidecar's (PDS-unknown) lexicon when true.
+            const response = await agent.com.atproto.repo.applyWrites({
+              repo: groupDid,
+              ...(input.validate === false ? { validate: false } : {}),
+              ...(input.swapCommit !== undefined ? { swapCommit: input.swapCommit } : {}),
+              writes: [
+                {
+                  $type: 'com.atproto.repo.applyWrites#create',
+                  collection: input.collection,
+                  rkey: input.rkey,
+                  value: input.record,
+                },
+                {
+                  $type: 'com.atproto.repo.applyWrites#create',
+                  collection: AUTHORSHIP_COLLECTION,
+                  rkey: sidecarRkey,
+                  value: sidecar,
+                },
+              ],
+            })
+            const subjectResult = response.data.results?.[0]
+            if (
+              subjectResult === undefined ||
+              subjectResult.$type !== 'com.atproto.repo.applyWrites#createResult'
+            ) {
+              throw new UpstreamFailureError(
+                'PDS applyWrites returned no result for the created record',
+              )
+            }
+            return {
+              uri: subjectResult.uri,
+              cid: subjectResult.cid,
+              ...(response.data.commit !== undefined ? { commit: response.data.commit } : {}),
+              ...(subjectResult.validationStatus !== undefined
+                ? { validationStatus: subjectResult.validationStatus }
+                : {}),
+            }
+          }
+
+          const response = await agent.com.atproto.repo.putRecord({ ...input, repo: groupDid })
+          try {
+            await agent.com.atproto.repo.createRecord({
+              repo: groupDid,
+              collection: AUTHORSHIP_COLLECTION,
+              rkey: sidecarRkey,
+              record: sidecar,
+            })
+          } catch (err) {
+            ctx.logger.warn(
+              { err, uri: recordUri },
+              'Failed to write authorship sidecar for legacy record; run admin.backfillAuthorship to repair',
+            )
+          }
+          return response.data
+        })
+      }
 
       const postOps: Promise<unknown>[] = [
         ctx.audit.log(groupDb, callerDid, operation, 'permitted', {
@@ -74,7 +202,7 @@ export default function (server: Server, ctx: AppContext) {
           groupDb
             .insertInto('group_record_authors')
             .values({
-              record_uri: response.data.uri,
+              record_uri: output.uri,
               author_did: callerDid,
               collection: input.collection,
             })
@@ -84,7 +212,7 @@ export default function (server: Server, ctx: AppContext) {
       }
       await Promise.all(postOps)
 
-      return jsonResponse(response.data)
+      return jsonResponse(output)
     },
   }
   registerAuthedMethod(server, 'app.certified.group.repo.putRecord', ctx, config)

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -98,6 +98,11 @@ export function sqliteToIso(timestamp: string): string {
   return new Date(timestamp + 'Z').toISOString()
 }
 
+/** Convert an ISO 8601 timestamp to SQLite DATETIME format (UTC, no timezone). */
+export function isoToSqlite(iso: string): string {
+  return new Date(iso).toISOString().replace('T', ' ').slice(0, 19)
+}
+
 export function encodeCursor(payload: string): string {
   return Buffer.from(payload).toString('base64')
 }

--- a/src/authorship.test.ts
+++ b/src/authorship.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { InvalidRequestError } from '@atproto/xrpc-server'
+import {
+  AUTHORSHIP_COLLECTION,
+  authorshipRkey,
+  authorshipUri,
+  buildAuthorshipRecord,
+  assertNotAuthorshipCollection,
+} from './authorship.js'
+
+describe('authorshipRkey', () => {
+  it('composes <collection>:<rkey>', () => {
+    expect(authorshipRkey('app.bsky.feed.post', '3abc123')).toBe('app.bsky.feed.post:3abc123')
+  })
+
+  it('is deterministic', () => {
+    expect(authorshipRkey('app.bsky.feed.post', 'x')).toBe(
+      authorshipRkey('app.bsky.feed.post', 'x'),
+    )
+  })
+
+  it('stays within the 512-char rkey limit via sha256 fallback', () => {
+    const longRkey = 'r'.repeat(500)
+    const composed = authorshipRkey('app.bsky.feed.post', longRkey)
+    expect(composed.length).toBeLessThanOrEqual(512)
+    // sha256 hex — still a valid rkey charset
+    expect(composed).toMatch(/^[a-f0-9]{64}$/)
+    // and still deterministic
+    expect(authorshipRkey('app.bsky.feed.post', longRkey)).toBe(composed)
+  })
+
+  it('only uses rkey-legal characters', () => {
+    expect(authorshipRkey('app.bsky.actor.profile', 'self')).toMatch(/^[A-Za-z0-9._:~-]+$/)
+  })
+})
+
+describe('authorshipUri', () => {
+  it('points at the sidecar in the group repo', () => {
+    expect(authorshipUri('did:plc:group1', 'app.bsky.feed.post', '3abc')).toBe(
+      `at://did:plc:group1/${AUTHORSHIP_COLLECTION}/app.bsky.feed.post:3abc`,
+    )
+  })
+})
+
+describe('buildAuthorshipRecord', () => {
+  it('builds a typed record with subject, author, createdAt', () => {
+    const record = buildAuthorshipRecord({
+      subject: 'at://did:plc:group1/app.bsky.feed.post/3abc',
+      author: 'did:plc:member1',
+    })
+    expect(record.$type).toBe(AUTHORSHIP_COLLECTION)
+    expect(record.subject).toBe('at://did:plc:group1/app.bsky.feed.post/3abc')
+    expect(record.author).toBe('did:plc:member1')
+    expect(Date.parse(record.createdAt)).not.toBeNaN()
+    expect('via' in record).toBe(false)
+  })
+
+  it('includes via when supplied (API-key writes)', () => {
+    const record = buildAuthorshipRecord({
+      subject: 'at://did:plc:group1/app.bsky.feed.post/3abc',
+      author: 'did:plc:member1',
+      via: 'cgsk_ref1',
+    })
+    expect(record.via).toBe('cgsk_ref1')
+  })
+
+  it('preserves an explicit createdAt (backfill path)', () => {
+    const record = buildAuthorshipRecord({
+      subject: 'at://did:plc:group1/app.bsky.feed.post/3abc',
+      author: 'did:plc:member1',
+      createdAt: '2025-06-01T00:00:00.000Z',
+    })
+    expect(record.createdAt).toBe('2025-06-01T00:00:00.000Z')
+  })
+})
+
+describe('assertNotAuthorshipCollection', () => {
+  it('rejects the service-managed collection', () => {
+    expect(() => assertNotAuthorshipCollection(AUTHORSHIP_COLLECTION)).toThrow(InvalidRequestError)
+  })
+
+  it('passes any other collection', () => {
+    expect(() => assertNotAuthorshipCollection('app.bsky.feed.post')).not.toThrow()
+    expect(() => assertNotAuthorshipCollection('app.certified.group.authorship2')).not.toThrow()
+  })
+})

--- a/src/authorship.ts
+++ b/src/authorship.ts
@@ -1,0 +1,88 @@
+import { createHash } from 'node:crypto'
+import { InvalidRequestError } from '@atproto/xrpc-server'
+
+/**
+ * Record authorship sidecars.
+ *
+ * In atproto, a repo has exactly one author: the repo's DID. Records written
+ * through CGS are therefore all signed by the *group*, and which member
+ * actually wrote a record is invisible to the network. CGS tracks that fact
+ * internally (the per-group `group_record_authors` table), but an internal
+ * SQLite table is neither public nor interoperable: it does not appear on the
+ * firehose, is not part of CAR backups, and is lost if the group migrates to
+ * another group service.
+ *
+ * The fix is to publish attribution *into the group's repo* as a sidecar
+ * record (`app.certified.group.authorship`), written in the same commit as the
+ * record it describes. The repo becomes the source of truth for authorship;
+ * `group_record_authors` is demoted to a derived index used for fast RBAC
+ * checks (and is rebuildable from the repo — see the rehydration pass in
+ * `group.import`). See docs/design/record-authorship.md.
+ */
+export const AUTHORSHIP_COLLECTION = 'app.certified.group.authorship'
+
+/** atproto record keys are capped at 512 characters. */
+const MAX_RKEY_LENGTH = 512
+
+/**
+ * Value of an `app.certified.group.authorship` record. Declared as a type
+ * alias (not an interface) so it structurally satisfies the
+ * `{ [key: string]: unknown }` record value expected by the PDS client.
+ */
+export type AuthorshipRecord = {
+  $type: typeof AUTHORSHIP_COLLECTION
+  /** AT-URI of the record this attribution describes. */
+  subject: string
+  /** DID of the group member who created the subject record. */
+  author: string
+  /** API-key ref, when the record was written by a key-authenticated daemon. */
+  via?: string
+  createdAt: string
+}
+
+/**
+ * Deterministic sidecar rkey for a subject record, so attribution is a direct
+ * `com.atproto.repo.getRecord` away (no scan): `<collection>:<rkey>`. Both
+ * NSIDs and rkeys draw from the rkey-legal charset (`[A-Za-z0-9._:~-]`), so
+ * the composite is always a valid rkey — except for length, where we fall
+ * back to the sha256 hex of the composite (64 chars, also rkey-legal).
+ */
+export function authorshipRkey(collection: string, rkey: string): string {
+  const readable = `${collection}:${rkey}`
+  if (readable.length <= MAX_RKEY_LENGTH) return readable
+  return createHash('sha256').update(readable).digest('hex')
+}
+
+/** AT-URI of the authorship sidecar for a subject record. */
+export function authorshipUri(groupDid: string, collection: string, rkey: string): string {
+  return `at://${groupDid}/${AUTHORSHIP_COLLECTION}/${authorshipRkey(collection, rkey)}`
+}
+
+export function buildAuthorshipRecord(opts: {
+  subject: string
+  author: string
+  via?: string
+  createdAt?: string
+}): AuthorshipRecord {
+  return {
+    $type: AUTHORSHIP_COLLECTION,
+    subject: opts.subject,
+    author: opts.author,
+    ...(opts.via !== undefined ? { via: opts.via } : {}),
+    createdAt: opts.createdAt ?? new Date().toISOString(),
+  }
+}
+
+/**
+ * The authorship collection is service-managed: only CGS itself writes it, as
+ * a sidecar to the record it attributes. A caller writing (or deleting) it
+ * directly could forge or erase attribution, so the record endpoints reject
+ * it up front.
+ */
+export function assertNotAuthorshipCollection(collection: string): void {
+  if (collection === AUTHORSHIP_COLLECTION) {
+    throw new InvalidRequestError(
+      `The ${AUTHORSHIP_COLLECTION} collection is service-managed and cannot be written directly`,
+    )
+  }
+}

--- a/tests/admin.backfill-authorship.test.ts
+++ b/tests/admin.backfill-authorship.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import type { Kysely } from 'kysely'
+import type { GroupDatabase } from '../src/db/schema.js'
+import {
+  createTestContext,
+  createTestApp,
+  seedAuthorship,
+  TEST_ADMIN_PASSWORD,
+} from './helpers/mock-server.js'
+import adminBackfillHandler from '../src/api/admin/backfillAuthorship.js'
+import { AUTHORSHIP_COLLECTION, authorshipRkey } from '../src/authorship.js'
+import type { AppContext } from '../src/context.js'
+
+const NSID = 'app.certified.group.admin.backfillAuthorship'
+const GROUP = 'did:plc:testgroup'
+const POST = 'app.bsky.feed.post'
+
+const basic = (user: string, pass: string): string =>
+  'Basic ' + Buffer.from(`${user}:${pass}`).toString('base64')
+
+/**
+ * A pdsAgents mock for the backfill: `existingSidecarRkeys` are returned by
+ * listRecords (paged, `pageSize` per page) and every applyWrites call is
+ * recorded.
+ */
+function backfillPdsAgents(existingSidecarRkeys: string[], pageSize = 100) {
+  const applyWritesCalls: any[] = []
+  const agent = {
+    com: {
+      atproto: {
+        repo: {
+          listRecords: async (params: { cursor?: string }) => {
+            const start = params.cursor !== undefined ? parseInt(params.cursor, 10) : 0
+            const page = existingSidecarRkeys.slice(start, start + pageSize)
+            const next = start + page.length
+            return {
+              data: {
+                records: page.map((rkey) => ({
+                  uri: `at://${GROUP}/${AUTHORSHIP_COLLECTION}/${rkey}`,
+                  value: {},
+                })),
+                ...(next < existingSidecarRkeys.length ? { cursor: String(next) } : {}),
+              },
+            }
+          },
+          applyWrites: async (input: any) => {
+            applyWritesCalls.push(input)
+            return { data: { commit: { cid: 'bafycommit', rev: '3rev' }, results: [] } }
+          },
+        },
+      },
+    },
+  }
+  const pdsAgents = {
+    get: async () => agent,
+    withAgent: async (_did: string, fn: (a: any) => Promise<any>) => fn(agent),
+    invalidate: () => {},
+  }
+  return { applyWritesCalls, pdsAgents: pdsAgents as unknown as AppContext['pdsAgents'] }
+}
+
+describe('admin.backfillAuthorship', () => {
+  let ctx: AppContext
+  let groupDb: Kysely<GroupDatabase>
+  let app: express.Express
+
+  beforeEach(async () => {
+    const tc = await createTestContext()
+    ctx = tc.ctx
+    groupDb = tc.groupDb
+    app = createTestApp(ctx, (server, appCtx) => {
+      adminBackfillHandler(server, appCtx)
+    })
+  })
+
+  afterEach(async () => {
+    await groupDb.destroy()
+  })
+
+  const post = (body: object) =>
+    request(app)
+      .post(`/xrpc/${NSID}`)
+      .set('Authorization', basic('admin', TEST_ADMIN_PASSWORD))
+      .send(body)
+
+  it('writes sidecars for tracked rows that lack one, skipping existing', async () => {
+    await seedAuthorship(groupDb, `at://${GROUP}/${POST}/aaa`, 'did:plc:alice', POST)
+    await seedAuthorship(groupDb, `at://${GROUP}/${POST}/bbb`, 'did:plc:bob', POST)
+    // aaa already has a sidecar in the repo; bbb does not
+    const recorder = backfillPdsAgents([authorshipRkey(POST, 'aaa')])
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await post({ repo: GROUP })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({
+      groupDid: GROUP,
+      created: 1,
+      alreadyPresent: 1,
+      total: 2,
+    })
+
+    expect(recorder.applyWritesCalls).toHaveLength(1)
+    const { writes } = recorder.applyWritesCalls[0]
+    expect(writes).toHaveLength(1)
+    expect(writes[0]).toMatchObject({
+      collection: AUTHORSHIP_COLLECTION,
+      rkey: authorshipRkey(POST, 'bbb'),
+    })
+    expect(writes[0].value).toMatchObject({
+      $type: AUTHORSHIP_COLLECTION,
+      subject: `at://${GROUP}/${POST}/bbb`,
+      author: 'did:plc:bob',
+    })
+    // createdAt preserved from the tracked row (ISO format)
+    expect(Date.parse(writes[0].value.createdAt)).not.toBeNaN()
+
+    // Audit-logged as actor `admin`
+    const audit = await groupDb.selectFrom('group_audit_log').selectAll().execute()
+    expect(audit).toHaveLength(1)
+    expect(audit[0]).toMatchObject({
+      actor_did: 'admin',
+      action: 'admin.backfillAuthorship',
+      result: 'permitted',
+    })
+  })
+
+  it('is a no-op when every row already has a sidecar', async () => {
+    await seedAuthorship(groupDb, `at://${GROUP}/${POST}/aaa`, 'did:plc:alice', POST)
+    const recorder = backfillPdsAgents([authorshipRkey(POST, 'aaa')])
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await post({ repo: GROUP })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ created: 0, alreadyPresent: 1, total: 1 })
+    expect(recorder.applyWritesCalls).toHaveLength(0)
+  })
+
+  it('paginates the existing-sidecar listing', async () => {
+    await seedAuthorship(groupDb, `at://${GROUP}/${POST}/new1`, 'did:plc:alice', POST)
+    // 5 existing sidecars served 2 per page → 3 pages; none match new1
+    const existing = ['r1', 'r2', 'r3', 'r4', 'r5'].map((r) => authorshipRkey(POST, r))
+    const recorder = backfillPdsAgents(existing, 2)
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await post({ repo: GROUP })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ created: 1, alreadyPresent: 5, total: 1 })
+  })
+
+  it('chunks large backfills into 200-write commits', async () => {
+    const values = Array.from({ length: 201 }, (_, i) => ({
+      record_uri: `at://${GROUP}/${POST}/rk${i}`,
+      author_did: 'did:plc:alice',
+      collection: POST,
+    }))
+    await groupDb.insertInto('group_record_authors').values(values).execute()
+    const recorder = backfillPdsAgents([])
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await post({ repo: GROUP })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ created: 201, alreadyPresent: 0, total: 201 })
+    expect(recorder.applyWritesCalls).toHaveLength(2)
+    expect(recorder.applyWritesCalls[0].writes).toHaveLength(200)
+    expect(recorder.applyWritesCalls[1].writes).toHaveLength(1)
+  })
+
+  it('rejects a missing Authorization header', async () => {
+    const res = await request(app).post(`/xrpc/${NSID}`).send({ repo: GROUP })
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects a wrong admin password', async () => {
+    const res = await request(app)
+      .post(`/xrpc/${NSID}`)
+      .set('Authorization', basic('admin', 'wrong-password'))
+      .send({ repo: GROUP })
+    expect(res.status).toBe(401)
+  })
+
+  it('404s an unknown group', async () => {
+    const res = await post({ repo: 'did:plc:unknowngroup' })
+    expect(res.status).toBe(404)
+    expect(res.body.error).toBe('UnknownGroup')
+  })
+
+  it('surfaces unexpected resolver failures as-is (not UnknownGroup)', async () => {
+    ctx.authVerifier = {
+      ...ctx.authVerifier,
+      resolveRepoToGroup: async () => {
+        throw new Error('resolver down')
+      },
+    } as unknown as AppContext['authVerifier']
+    // Re-register handlers against the patched verifier
+    app = createTestApp(ctx, (server, appCtx) => {
+      adminBackfillHandler(server, appCtx)
+    })
+
+    const res = await post({ repo: GROUP })
+    expect(res.status).toBe(500)
+  })
+})

--- a/tests/authorship-sidecars.test.ts
+++ b/tests/authorship-sidecars.test.ts
@@ -1,0 +1,464 @@
+/**
+ * Authorship sidecar behavior of the record endpoints: every create writes an
+ * app.certified.group.authorship record into the group repo (atomically with
+ * the subject record where possible), deletes clean the sidecar up, and the
+ * sidecar collection itself is service-managed (direct writes rejected).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import { XRPCError as ClientXRPCError } from '@atproto/xrpc'
+import {
+  createTestContext,
+  createTestApp,
+  seedMember,
+  seedAuthorship,
+} from './helpers/mock-server.js'
+import createRecordHandler from '../src/api/repo/createRecord.js'
+import putRecordHandler from '../src/api/repo/putRecord.js'
+import deleteRecordHandler from '../src/api/repo/deleteRecord.js'
+import { AUTHORSHIP_COLLECTION } from '../src/authorship.js'
+import type { AppContext } from '../src/context.js'
+import type { Kysely } from 'kysely'
+import type { GroupDatabase } from '../src/db/schema.js'
+
+const GROUP = 'did:plc:testgroup'
+const CALLER = 'did:plc:testuser'
+const POST = 'app.bsky.feed.post'
+
+interface RecordedCall {
+  method: string
+  input: any
+}
+
+/**
+ * A pdsAgents mock that records every repo call. `recordExists` controls the
+ * getRecord probe (false → RecordNotFound); `failSidecarOps` makes writes and
+ * deletes of the authorship collection throw (to exercise best-effort paths);
+ * `getRecordFails` makes the probe throw a non-RecordNotFound error;
+ * `applyWritesEmptyResults` / `noCommit` shape degenerate PDS responses.
+ */
+function recordingPdsAgents(
+  opts: {
+    recordExists?: boolean
+    failSidecarOps?: boolean
+    getRecordFails?: boolean
+    applyWritesEmptyResults?: boolean
+    noCommit?: boolean
+  } = {},
+) {
+  const calls: RecordedCall[] = []
+  const agent = {
+    com: {
+      atproto: {
+        repo: {
+          createRecord: async (input: any) => {
+            calls.push({ method: 'createRecord', input })
+            if (opts.failSidecarOps && input.collection === AUTHORSHIP_COLLECTION) {
+              throw new ClientXRPCError(500, 'InternalServerError', 'boom')
+            }
+            return {
+              data: {
+                uri: `at://${GROUP}/${input.collection}/${input.rkey ?? 'generated'}`,
+                cid: 'bafytest',
+              },
+            }
+          },
+          putRecord: async (input: any) => {
+            calls.push({ method: 'putRecord', input })
+            return {
+              data: { uri: `at://${GROUP}/${input.collection}/${input.rkey}`, cid: 'bafytest' },
+            }
+          },
+          deleteRecord: async (input: any) => {
+            calls.push({ method: 'deleteRecord', input })
+            if (opts.failSidecarOps && input.collection === AUTHORSHIP_COLLECTION) {
+              throw new ClientXRPCError(500, 'InternalServerError', 'boom')
+            }
+            return { data: {} }
+          },
+          getRecord: async (input: any) => {
+            calls.push({ method: 'getRecord', input })
+            if (opts.getRecordFails) {
+              throw new ClientXRPCError(400, 'InvalidRequest', 'probe exploded')
+            }
+            if (opts.recordExists) {
+              return { data: { uri: `at://${GROUP}/${input.collection}/${input.rkey}` } }
+            }
+            throw new ClientXRPCError(400, 'RecordNotFound', 'Could not locate record')
+          },
+          applyWrites: async (input: any) => {
+            calls.push({ method: 'applyWrites', input })
+            return {
+              data: {
+                ...(opts.noCommit ? {} : { commit: { cid: 'bafycommit', rev: '3testrev' } }),
+                results: opts.applyWritesEmptyResults
+                  ? []
+                  : input.writes.map((w: any) =>
+                      w.$type === 'com.atproto.repo.applyWrites#delete'
+                        ? { $type: 'com.atproto.repo.applyWrites#deleteResult' }
+                        : {
+                            $type: `${w.$type}Result`,
+                            uri: `at://${GROUP}/${w.collection}/${w.rkey ?? 'generated'}`,
+                            cid: 'bafytest',
+                            validationStatus: 'unknown',
+                          },
+                    ),
+              },
+            }
+          },
+        },
+      },
+    },
+  }
+  const pdsAgents = {
+    get: async () => agent,
+    withAgent: async (_did: string, fn: (a: any) => Promise<any>) => fn(agent),
+    invalidate: () => {},
+  }
+  return { calls, pdsAgents: pdsAgents as unknown as AppContext['pdsAgents'] }
+}
+
+describe('createRecord — authorship sidecar', () => {
+  let ctx: AppContext
+  let groupDb: Kysely<GroupDatabase>
+  let calls: RecordedCall[]
+
+  beforeEach(async () => {
+    const test = await createTestContext()
+    ctx = test.ctx
+    groupDb = test.groupDb
+    const recorder = recordingPdsAgents()
+    calls = recorder.calls
+    ctx.pdsAgents = recorder.pdsAgents
+    await seedMember(groupDb, CALLER, 'member')
+  })
+
+  const app = () => createTestApp(ctx, (s, c) => createRecordHandler(s, c))
+
+  it('writes the record and its sidecar in ONE applyWrites commit', async () => {
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.createRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'post1', record: { text: 'hello' } })
+
+    expect(res.status).toBe(200)
+    expect(res.body.uri).toBe(`at://${GROUP}/${POST}/post1`)
+    expect(res.body.cid).toBe('bafytest')
+    // Commit meta and validationStatus propagated from the applyWrites result
+    expect(res.body.commit).toMatchObject({ cid: 'bafycommit' })
+    expect(res.body.validationStatus).toBe('unknown')
+
+    expect(calls.map((c) => c.method)).toEqual(['applyWrites'])
+    const { writes } = calls[0].input
+    expect(writes).toHaveLength(2)
+    expect(writes[0]).toMatchObject({ collection: POST, rkey: 'post1', value: { text: 'hello' } })
+    expect(writes[1]).toMatchObject({
+      collection: AUTHORSHIP_COLLECTION,
+      rkey: `${POST}:post1`,
+    })
+    expect(writes[1].value).toMatchObject({
+      $type: AUTHORSHIP_COLLECTION,
+      subject: `at://${GROUP}/${POST}/post1`,
+      author: CALLER,
+    })
+    expect(Date.parse(writes[1].value.createdAt)).not.toBeNaN()
+    expect('via' in writes[1].value).toBe(false)
+  })
+
+  it('mints a TID rkey when none is supplied and embeds it in the sidecar subject', async () => {
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.createRecord')
+      .send({ repo: GROUP, collection: POST, record: { text: 'hi' } })
+
+    expect(res.status).toBe(200)
+    const { writes } = calls[0].input
+    const rkey = writes[0].rkey
+    expect(rkey).toBeTruthy()
+    expect(res.body.uri).toBe(`at://${GROUP}/${POST}/${rkey}`)
+    expect(writes[1].rkey).toBe(`${POST}:${rkey}`)
+    expect(writes[1].value.subject).toBe(`at://${GROUP}/${POST}/${rkey}`)
+  })
+
+  it('records the API key ref in the sidecar via field', async () => {
+    ctx.authVerifier = {
+      ...ctx.authVerifier,
+      xrpcAuth() {
+        return async () => ({
+          credentials: {
+            callerDid: CALLER,
+            groupDid: GROUP,
+            legacyAud: false,
+            authKind: 'apiKey' as const,
+            scopes: [`repo:${POST}?action=create`],
+            apiKeyRef: 'ref1',
+          },
+        })
+      },
+    } as unknown as AppContext['authVerifier']
+
+    const res = await request(app())
+      .post(`/xrpc/com.atproto.repo.createRecord?repo=${GROUP}`)
+      .send({ repo: GROUP, collection: POST, rkey: 'bot1', record: { text: 'beep' } })
+
+    expect(res.status).toBe(200)
+    expect(calls[0].input.writes[1].value.via).toBe('ref1')
+  })
+
+  it('passes validate:false through but degrades validate:true to default', async () => {
+    await request(app())
+      .post('/xrpc/com.atproto.repo.createRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'a', record: {}, validate: false })
+    expect(calls[0].input.validate).toBe(false)
+
+    await request(app())
+      .post('/xrpc/com.atproto.repo.createRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'b', record: {}, validate: true })
+    expect('validate' in calls[1].input).toBe(false)
+  })
+
+  it('rejects direct writes to the authorship collection', async () => {
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.createRecord')
+      .send({
+        repo: GROUP,
+        collection: AUTHORSHIP_COLLECTION,
+        record: { subject: 'at://x/y/z', author: 'did:plc:forged' },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('InvalidRequest')
+    expect(calls).toHaveLength(0)
+  })
+
+  it('502s when the PDS returns no applyWrites result for the record', async () => {
+    const recorder = recordingPdsAgents({ applyWritesEmptyResults: true })
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.createRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'x', record: {} })
+
+    expect(res.status).toBe(502)
+  })
+
+  it('omits commit meta when the PDS response has none', async () => {
+    const recorder = recordingPdsAgents({ noCommit: true })
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.createRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'y', record: {} })
+
+    expect(res.status).toBe(200)
+    expect('commit' in res.body).toBe(false)
+  })
+})
+
+describe('putRecord — authorship sidecar', () => {
+  let ctx: AppContext
+  let groupDb: Kysely<GroupDatabase>
+
+  beforeEach(async () => {
+    const test = await createTestContext()
+    ctx = test.ctx
+    groupDb = test.groupDb
+    await seedMember(groupDb, CALLER, 'member')
+  })
+
+  const app = () => createTestApp(ctx, (s, c) => putRecordHandler(s, c))
+
+  it('genuinely new record: writes record + sidecar in one applyWrites commit', async () => {
+    const recorder = recordingPdsAgents({ recordExists: false })
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.putRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'new1', record: { text: 'x' } })
+
+    expect(res.status).toBe(200)
+    expect(recorder.calls.map((c) => c.method)).toEqual(['getRecord', 'applyWrites'])
+    const { writes } = recorder.calls[1].input
+    expect(writes).toHaveLength(2)
+    expect(writes[1]).toMatchObject({ collection: AUTHORSHIP_COLLECTION, rkey: `${POST}:new1` })
+    expect(writes[1].value).toMatchObject({
+      subject: `at://${GROUP}/${POST}/new1`,
+      author: CALLER,
+    })
+  })
+
+  it('legacy record (exists on PDS, untracked): putRecord then best-effort sidecar', async () => {
+    const recorder = recordingPdsAgents({ recordExists: true })
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.putRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'old1', record: { text: 'edited' } })
+
+    expect(res.status).toBe(200)
+    expect(recorder.calls.map((c) => c.method)).toEqual(['getRecord', 'putRecord', 'createRecord'])
+    const sidecarCall = recorder.calls[2].input
+    expect(sidecarCall.collection).toBe(AUTHORSHIP_COLLECTION)
+    expect(sidecarCall.rkey).toBe(`${POST}:old1`)
+    expect(sidecarCall.record).toMatchObject({
+      subject: `at://${GROUP}/${POST}/old1`,
+      author: CALLER,
+    })
+    // The edit attributes the record to the caller (existing semantics)
+    const rows = await groupDb.selectFrom('group_record_authors').selectAll().execute()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].author_did).toBe(CALLER)
+  })
+
+  it('legacy-record sidecar failure does not fail the request', async () => {
+    const recorder = recordingPdsAgents({ recordExists: true, failSidecarOps: true })
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.putRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'old2', record: { text: 'edited' } })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('propagates commit and validationStatus on the applyWrites path', async () => {
+    const recorder = recordingPdsAgents({ recordExists: false })
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.putRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'new2', record: {} })
+
+    expect(res.status).toBe(200)
+    expect(res.body.commit).toMatchObject({ cid: 'bafycommit' })
+    expect(res.body.validationStatus).toBe('unknown')
+  })
+
+  it('surfaces a non-RecordNotFound probe failure instead of guessing', async () => {
+    const recorder = recordingPdsAgents({ getRecordFails: true })
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.putRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'new3', record: {} })
+
+    // The probe's 4xx is forwarded; no write was attempted
+    expect(res.status).toBe(400)
+    expect(recorder.calls.map((c) => c.method)).toEqual(['getRecord'])
+  })
+
+  it('502s when the PDS returns no applyWrites result for a new record', async () => {
+    const recorder = recordingPdsAgents({ applyWritesEmptyResults: true })
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.putRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'new4', record: {} })
+
+    expect(res.status).toBe(502)
+  })
+
+  it('omits commit meta when the PDS response has none (new record)', async () => {
+    const recorder = recordingPdsAgents({ noCommit: true })
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.putRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'new5', record: {} })
+
+    expect(res.status).toBe(200)
+    expect('commit' in res.body).toBe(false)
+  })
+
+  it('tracked record update: plain putRecord, sidecar untouched', async () => {
+    const recorder = recordingPdsAgents()
+    ctx.pdsAgents = recorder.pdsAgents
+    await seedAuthorship(groupDb, `at://${GROUP}/${POST}/xyz`, CALLER, POST)
+
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.putRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'xyz', record: { text: 'v2' } })
+
+    expect(res.status).toBe(200)
+    expect(recorder.calls.map((c) => c.method)).toEqual(['putRecord'])
+    // Authorship remains with the original author
+    const rows = await groupDb.selectFrom('group_record_authors').selectAll().execute()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].author_did).toBe(CALLER)
+  })
+
+  it('rejects direct writes to the authorship collection', async () => {
+    const recorder = recordingPdsAgents()
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.putRecord')
+      .send({
+        repo: GROUP,
+        collection: AUTHORSHIP_COLLECTION,
+        rkey: `${POST}:post1`,
+        record: { subject: `at://${GROUP}/${POST}/post1`, author: 'did:plc:forged' },
+      })
+
+    expect(res.status).toBe(400)
+    expect(recorder.calls).toHaveLength(0)
+  })
+})
+
+describe('deleteRecord — authorship sidecar', () => {
+  let ctx: AppContext
+  let groupDb: Kysely<GroupDatabase>
+
+  beforeEach(async () => {
+    const test = await createTestContext()
+    ctx = test.ctx
+    groupDb = test.groupDb
+    await seedMember(groupDb, CALLER, 'member')
+  })
+
+  const app = () => createTestApp(ctx, (s, c) => deleteRecordHandler(s, c))
+
+  it('deletes the sidecar after the subject record', async () => {
+    const recorder = recordingPdsAgents()
+    ctx.pdsAgents = recorder.pdsAgents
+    await seedAuthorship(groupDb, `at://${GROUP}/${POST}/abc`, CALLER, POST)
+
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.deleteRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'abc' })
+
+    expect(res.status).toBe(200)
+    expect(recorder.calls.map((c) => c.method)).toEqual(['deleteRecord', 'deleteRecord'])
+    expect(recorder.calls[0].input).toMatchObject({ collection: POST, rkey: 'abc' })
+    expect(recorder.calls[1].input).toMatchObject({
+      collection: AUTHORSHIP_COLLECTION,
+      rkey: `${POST}:abc`,
+    })
+  })
+
+  it('sidecar deletion failure does not fail the request', async () => {
+    const recorder = recordingPdsAgents({ failSidecarOps: true })
+    ctx.pdsAgents = recorder.pdsAgents
+    await seedAuthorship(groupDb, `at://${GROUP}/${POST}/abc`, CALLER, POST)
+
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.deleteRecord')
+      .send({ repo: GROUP, collection: POST, rkey: 'abc' })
+
+    expect(res.status).toBe(200)
+    // Subject-side cleanup still happened
+    const rows = await groupDb.selectFrom('group_record_authors').selectAll().execute()
+    expect(rows).toHaveLength(0)
+  })
+
+  it('rejects direct deletes of authorship records', async () => {
+    const recorder = recordingPdsAgents()
+    ctx.pdsAgents = recorder.pdsAgents
+
+    const res = await request(app())
+      .post('/xrpc/com.atproto.repo.deleteRecord')
+      .send({ repo: GROUP, collection: AUTHORSHIP_COLLECTION, rkey: `${POST}:abc` })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('InvalidRequest')
+    expect(recorder.calls).toHaveLength(0)
+  })
+})

--- a/tests/helpers/mock-server.ts
+++ b/tests/helpers/mock-server.ts
@@ -70,6 +70,33 @@ export async function createTestContext(overrides?: Partial<AppContext>): Promis
                   cid: 'bafytest',
                 },
               }),
+              // Default: no record exists (putRecord's existence probe treats
+              // RecordNotFound as "new record"). Tests exercising the
+              // legacy-record path override this to resolve.
+              getRecord: async (_params: unknown) => {
+                const { XRPCError } = await import('@atproto/xrpc')
+                throw new XRPCError(400, 'RecordNotFound', 'Could not locate record')
+              },
+              listRecords: async (_params: unknown) => ({
+                data: { records: [] as unknown[] },
+              }),
+              // Echo each write back as a result, the way the real PDS does.
+              applyWrites: async (input: {
+                writes: Array<{ $type: string; collection: string; rkey?: string }>
+              }) => ({
+                data: {
+                  commit: { cid: 'bafycommit', rev: '3testrev' },
+                  results: input.writes.map((w) =>
+                    w.$type === 'com.atproto.repo.applyWrites#delete'
+                      ? { $type: 'com.atproto.repo.applyWrites#deleteResult' }
+                      : {
+                          $type: `${w.$type}Result`,
+                          uri: `at://did:plc:testgroup/${w.collection}/${w.rkey ?? 'generated'}`,
+                          cid: 'bafytest',
+                        },
+                  ),
+                },
+              }),
               uploadBlob: async () => ({
                 data: {
                   blob: {

--- a/tests/import.test.ts
+++ b/tests/import.test.ts
@@ -95,6 +95,96 @@ describe('group.import', () => {
     expect(owner!.role).toBe('owner')
   })
 
+  it('rehydrates the authorship index from repo sidecar records', async () => {
+    // A group migrating from another CGS instance arrives with
+    // app.certified.group.authorship sidecars already in its repo — the repo
+    // is the source of truth, and import rebuilds the internal index from it.
+    const listRecords = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          records: [
+            {
+              uri: 'at://did:plc:existingaccount/app.certified.group.authorship/app.bsky.feed.post:aaa',
+              value: {
+                $type: 'app.certified.group.authorship',
+                subject: 'at://did:plc:existingaccount/app.bsky.feed.post/aaa',
+                author: 'did:plc:alice',
+                createdAt: '2025-06-01T12:00:00.000Z',
+              },
+            },
+            {
+              // malformed — skipped without failing the import
+              uri: 'at://did:plc:existingaccount/app.certified.group.authorship/junk',
+              value: { note: 'not an authorship record' },
+            },
+          ],
+          cursor: 'page2',
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          records: [
+            {
+              uri: 'at://did:plc:existingaccount/app.certified.group.authorship/app.bsky.feed.post:bbb',
+              value: {
+                subject: 'at://did:plc:existingaccount/app.bsky.feed.post/bbb',
+                author: 'did:plc:bob',
+              },
+            },
+          ],
+        },
+      })
+    vi.mocked(AtpAgent).mockImplementationOnce(
+      () =>
+        ({
+          login: vi.fn().mockResolvedValue(undefined),
+          com: { atproto: { repo: { listRecords } } },
+        }) as any,
+    )
+
+    const res = await request(app).post(ENDPOINT).send(validBody)
+    expect(res.status).toBe(200)
+
+    const rows = await groupDb
+      .selectFrom('group_record_authors')
+      .selectAll()
+      .orderBy('record_uri', 'asc')
+      .execute()
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({
+      record_uri: 'at://did:plc:existingaccount/app.bsky.feed.post/aaa',
+      author_did: 'did:plc:alice',
+      collection: 'app.bsky.feed.post',
+      // Original creation time preserved from the sidecar (SQLite format)
+      created_at: '2025-06-01 12:00:00',
+    })
+    expect(rows[1]).toMatchObject({
+      record_uri: 'at://did:plc:existingaccount/app.bsky.feed.post/bbb',
+      author_did: 'did:plc:bob',
+      collection: 'app.bsky.feed.post',
+    })
+    expect(listRecords).toHaveBeenCalledTimes(2)
+  })
+
+  it('import succeeds even when sidecar rehydration fails', async () => {
+    vi.mocked(AtpAgent).mockImplementationOnce(
+      () =>
+        ({
+          login: vi.fn().mockResolvedValue(undefined),
+          com: {
+            atproto: {
+              repo: { listRecords: vi.fn().mockRejectedValue(new Error('boom')) },
+            },
+          },
+        }) as any,
+    )
+
+    const res = await request(app).post(ENDPOINT).send(validBody)
+    expect(res.status).toBe(200)
+    expect(res.body.groupDid).toBe('did:plc:existingaccount')
+  })
+
   it('stores the resolved PDS url, not the configured group PDS', async () => {
     // Resolve the account to a different PDS than config.groupPdsUrl
     const test = await createTestContext({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,10 +30,10 @@ export default defineConfig({
       ],
       // Ratchet thresholds — only ever increase. See AGENTS.md.
       thresholds: {
-        statements: 94,
+        statements: 95,
         branches: 91,
         functions: 93,
-        lines: 94,
+        lines: 95,
       },
     },
   },


### PR DESCRIPTION
## Problem

Which group member authored a record is invisible outside CGS: the network only sees the group DID. CGS tracks authorship internally (`group_record_authors`) and in the admin-only audit log — same situation as Ma Earth's internal log (e.g. [mangaroa-farms/fruit-and-forage](https://maearth.com/mangaroa-farms/fruit-and-forage)): attribution exists, but it's private and tied to one service's database. Not public, not interoperable.

## Solution: authorship sidecar records

Every record created through CGS now gets an **`app.certified.group.authorship` sidecar written into the group's own repo, in the same `applyWrites` commit** as the record itself:

```jsonc
// at://<group>/app.certified.group.authorship/app.bsky.feed.post:3abc
{
  "$type": "app.certified.group.authorship",
  "subject": "at://did:plc:group/app.bsky.feed.post/3abc",
  "author": "did:plc:member1",
  "via": "cgsk_…",          // optional: API-key ref for daemon writes
  "createdAt": "2026-07-07T12:00:00.000Z"
}
```

Attribution is now readable by **any** atproto client via plain `com.atproto.repo.getRecord` (deterministic rkey `<collection>:<rkey>`, sha256 hex fallback past 512 chars), flows over the firehose, survives CAR exports and PDS/group-service migrations, and no longer depends on CGS's internal state. A frontend can render "created by @handle" without touching a CGS API.

Full rationale, options considered, atomicity analysis, trust model, and privacy caveats: **`docs/design/record-authorship.md`**.

## What's included

- **Atomic creates** — `createRecord` (and `putRecord` for genuinely new records, detected via a `getRecord` probe) batches subject + sidecar in one commit; CGS mints the TID client-side when the caller omits `rkey`
- **Service-managed collection** — direct `createRecord`/`putRecord`/`deleteRecord` against `app.certified.group.authorship` are rejected with `InvalidRequest` (a direct write could forge attribution; a direct delete could erase it)
- **Delete cleanup** — `deleteRecord` removes the subject's sidecar (best-effort, idempotent; legacy records without sidecars are fine)
- **Immutability preserved** — edits (incl. admin `putAnyRecord`) never rewrite attribution, matching the existing `onConflict().doNothing()` semantics
- **`group_record_authors` demoted to derived index** — `group.import` now rehydrates it from repo sidecars, so a group migrating from another CGS instance arrives with attribution and own-record permissions intact
- **Operator backfill** — new `app.certified.group.admin.backfillAuthorship` (HTTP Basic, like `setOwner`; idempotent; 200-write chunks) publishes sidecars for records created before this feature, preserving original author + timestamp. This is what makes existing deployments' records (e.g. Mangaroa's) publicly attributed
- **`validate` caveat** — `true` degrades to the PDS default on create paths (the commit-wide `applyWrites` flag would reject the sidecar's PDS-unknown lexicon); `false` passes through. Documented in lexicons, api-reference, and design doc

## Trust model & privacy (from the design doc)

- Sidecars are signed by the *group's* repo key: CGS attests "member X wrote this" — same trust level as the audit log, not cryptographic proof by the member
- Attribution makes member DIDs publicly linkable to content (more than the members-only `member.list` exposes). Groups for whom that's a problem shouldn't run the backfill; a per-group opt-out is a possible follow-up

## Testing

- 39 new tests (512 total): sidecar commit shape, TID minting, `via` for API-key writes, reserved-collection rejections on all three endpoints, delete cleanup + failure tolerance, legacy-record putRecord path, probe error surfacing, backfill (idempotency, pagination, 200-chunking, auth, unknown group), import rehydration (pagination, malformed-record skip, failure tolerance), unit tests for rkey/record helpers
- Coverage rose 94.83/91.73/93.06/94.83 → **95.31/91.94/93.44/95.31**; thresholds ratcheted 94/91/93/94 → **95/91/93/95** per policy

> Note: the full suite has a pre-existing intermittent flake (~1 in 3 full runs, a different test file each time, reproduced on `main`) — unrelated to this PR; worth a follow-up issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Record creation and updates now include public authorship attribution that can be viewed through standard repo access.
  * Added an operator backfill flow to restore missing authorship data for older records.
* **Bug Fixes**
  * Record deletions now clean up related attribution data.
  * Import flows now rebuild authorship indexes more reliably, even if some records are malformed or a backfill step fails.
* **Documentation**
  * Updated API and architecture docs to explain authorship behavior, deletion handling, and admin backfill usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->